### PR TITLE
Memoize jwt_payload method

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -142,7 +142,7 @@ module Rodauth
     end
 
     def jwt_payload
-      JWT.decode(jwt_token, jwt_secret, true, jwt_decode_opts.merge(:algorithm=>jwt_algorithm))[0]
+      @jwt_payload ||= JWT.decode(jwt_token, jwt_secret, true, jwt_decode_opts.merge(:algorithm=>jwt_algorithm))[0]
     rescue JWT::DecodeError
       json_response[json_response_error_key] = invalid_jwt_format_error_message
       response.status ||= json_response_error_status


### PR DESCRIPTION
File under "shooting myself in the foot": now that the session data is nested, in order to retrieve reserved claims from the JWT you need to write e.g. `jwt_payload['jti']`. This of course incurs an expensive call to JWT.decode each time. Here's a quick and dirty fix. 