### PR TITLE
Fix basic auth

### DIFF
--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -8,7 +8,7 @@ module Rodauth
       return @session if defined?(@session)
       sess = super
       return sess if sess[session_key]
-      return sess unless token = ((v = request.env['HTTP_AUTHORIZATION']) && v[/\A *Basic (.*)\n\z/, 1])
+      return sess unless token = ((v = request.env['HTTP_AUTHORIZATION']) && v[/\A *Basic (.*)\Z/, 1])
       username, password = token.unpack("m*").first.split(/:/, 2)
 
       if username && password

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -1,0 +1,7 @@
+# frozen-string-literal: true
+
+module Rodauth
+  HTTTBasicAuth = Feature.define(:http_basic_auth) do
+
+  end
+end

--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path("spec_helper", File.dirname(__FILE__))
+
+describe "Rodauth http basic auth feature" do
+  it "only handles the Basic scheme"
+
+  it "should work well with the jwt plugin"
+end


### PR DESCRIPTION
To fix #13 

I said I was going with splitting, but in order to keep the same multi-conditionals you rewrote my previous commits into, I could "split then assign then compare to scheme". This seems the least-effort fix. 

However, I leave you with a small script showing the differences between the 2 approaches, and you can later decide whether to switch to string splitting and how. 

```ruby
require 'benchmark/ips'
 Benchmark.ips do |x|
   HEADER = "Basic 2347z8h4r378043ef8ju43ew==\n"
 
   x.report("splitting") { HEADER.split(' ', 2)[1]  }
   x.report("matching") { HEADER[/\A *Basic (.*)\Z/, 1] }
 
   x.compare!
 end
```

```
Warming up --------------------------------------
           splitting    90.472k i/100ms
            matching    47.837k i/100ms
Calculating -------------------------------------
           splitting      1.500M (± 4.9%) i/s -      7.509M in   5.019272s
            matching    805.981k (± 5.1%) i/s -      4.066M in   5.058974s

Comparison:
           splitting:  1500012.1 i/s
            matching:   805980.9 i/s - 1.86x  slower
```