### PR TITLE
Implementing short access token, with a longer lived DB-stored refresh token

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,6 +39,7 @@ hashes by protecting access via database functions.
 * Session Expiration
 * Single Session (Only one active session per account)
 * JWT (JSON API support for all other features)
+* JWT Refresh (Access & Refresh Token)
 * Update Password Hash (when hash cost changes)
 * HTTP Basic Auth
 
@@ -269,6 +270,14 @@ versions of Sequel, switch the :Bignum symbols to Bignum constants.
       # Used by the password reset feature
       create_table(:account_password_reset_keys) do
         foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+        String :key, :null=>false
+        DateTime :deadline, deadline_opts[1]
+      end
+
+      # Used by the refresh token feature
+      create_table(:account_refresh_tokens) do
+        primary_key :id, :type=>:Bignum
+        foreign_key :account_id, :accounts, :type=>:Bignum
         String :key, :null=>false
         DateTime :deadline, deadline_opts[1]
       end

--- a/doc/jwt_refresh.rdoc
+++ b/doc/jwt_refresh.rdoc
@@ -1,0 +1,41 @@
+= Documentation for JWT Refresh Feature
+
+The jwt refresh feature adds support for JSON API Access and Refresh tokens.
+
+When this feature is used, an access and refresh token are provided
+at login, and for any subsequent POST to /jwt-refresh.
+
+This features depends and extends the JWT feature.
+
+== Auth Value Methods
+
+access_token_period :: Validity of an access token. Value in second, default is 30 minutes.
+refresh_token_deadline_interval :: validity of a refresh token. Default is 14 days.
+refresh_token_table :: Name of the table holding refresh token keys.
+refresh_token_id_column :: The column name in the refresh token keys table storing the id of each token. Primary key
+refresh_token_account_id_column, The column name in the refresh token table storing the account identifier,
+                    should be a foreign key referencing the accounts table.
+refresh_token_deadline_column :: The column name in the refresh token keys table storing
+                                                             the deadline after which the refresh token will no longer
+                                                             be valid.
+refresh_token_key_column, The column name in the refresh token keys table holding the refresh token value.
+token_separator :: Separator used in the refresh token to store the id and the refresh value per say.
+refresh_token_key_param :: Name of parameter in which the refresh token is provided when requesting a new token.
+                                                            Default is refresh_token
+access_token_key :: Name of the key in the response json holding the access token.
+                                                            Default is access_token
+refresh_token_key :: Name of the key in the response json holding the refresh token.
+                                                             Default is refresh_token
+json_invalid_refresh_token :: Error message when the provided refresh token is non existent, invalid or expired.
+
+
+
+== Auth Methods
+
+after_login :: Hook for specific processing after the user has been authenticated during login call.
+                                                            Default is to set the refresh token in the response body
+set_jwt_token :: An encoded JWT for the current session.
+jwt_session_hash :: The session hash used to create the session_jwt. Can be used to set extra JWT claims or override
+                                                            the defaults
+before_refresh_token :: Hooks for specific processing before the refresh token is computed
+after_refresh_token :: Hooks for specific processing once the refresh token has been set

--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -13,6 +13,8 @@ module Rodauth
     auth_value_method :refresh_token_key_column, :key
     auth_value_method :token_separator, '_'
     auth_value_method :refresh_token_key_param, 'refresh_token'
+    auth_value_method :access_token_key, 'access_token'
+    auth_value_method :refresh_token_key, 'refresh_token'
     auth_value_method :json_invalid_refresh_token, 'invalid refresh token'
 
     auth_methods(
@@ -20,6 +22,7 @@ module Rodauth
       :set_jwt_token,
       :jwt_session_hash,
       :before_refresh_token,
+      :after_refresh_token,
     )
 
     route do |r|
@@ -32,8 +35,8 @@ module Rodauth
             remove_refresh_token_key
             after_refresh_token
           end
-          json_response["refresh_token"]=format_refresh_token
-          json_response["access_token"]= session_jwt
+          json_response[refresh_token_key]=format_refresh_token
+          json_response[access_token_key]= session_jwt
         else
           json_response[json_response_error_key] = json_invalid_refresh_token
           response.status ||= json_response_error_status
@@ -54,7 +57,7 @@ module Rodauth
 
     def set_jwt_token(token)
       super(token)
-      json_response['access_token']= token
+      json_response[access_token_key]= token
     end
 
     def jwt_session_hash

--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -1,0 +1,164 @@
+# frozen-string-literal: true
+
+module Rodauth
+  JwtRefresh = Feature.define(:jwt_refresh) do
+    depends :jwt
+
+    auth_value_method :access_token_period, 30*60
+    auth_value_method :refresh_token_deadline_interval, {:days=>14}
+    auth_value_method :refresh_token_deadline_column, :deadline
+    auth_value_method :refresh_token_table, :account_refresh_tokens
+    auth_value_method :refresh_token_id_column, :id
+    auth_value_method :refresh_token_account_id_column, :account_id
+    auth_value_method :refresh_token_key_column, :key
+    auth_value_method :token_separator, '_'
+    auth_value_method :refresh_token_key_param, 'refresh_token'
+    auth_value_method :json_invalid_refresh_token, 'invalid refresh token'
+
+    auth_methods(
+      :after_login,
+      :set_jwt_token,
+      :jwt_session_hash,
+      :before_refresh_token,
+    )
+
+    route do |r|
+      r.post do
+        refresh_token = param(refresh_token_key_param)
+        if account_from_refresh_token(refresh_token)
+          transaction do
+            before_refresh_token
+            get_refresh_token
+            remove_refresh_token_key
+            after_refresh_token
+          end
+          json_response["refresh_token"]=format_refresh_token
+          json_response["access_token"]= session_jwt
+        else
+          json_response[json_response_error_key] = json_invalid_refresh_token
+          response.status ||= json_response_error_status
+        end
+        response['Content-Type'] ||= json_response_content_type
+        response.write(request.send(:convert_to_json, json_response))
+        request.halt
+      end
+    end
+
+    def after_login
+      super
+      # JWT login puts the token in the header.
+      # We put the refresh token in the body.
+      # Note, do not put the access_token in the body here, as the access token content is not yet finalised.
+      json_response['refresh_token']= get_refresh_token
+    end
+
+    def set_jwt_token(token)
+      super(token)
+      json_response['access_token']= token
+    end
+
+    def jwt_session_hash
+      h = super()
+      h.merge(
+          :exp => Time.now.to_i + access_token_period,
+          :iat => Time.now.to_i,
+          :nbf => Time.now.to_i - 5,
+          :jti => SecureRandom.hex(10),
+      )
+    end
+
+    # User hooks
+    def before_refresh_token
+    end
+
+    def after_refresh_token
+    end
+
+    private
+    attr_reader :refresh_token_key_value, :used_token_id, :inserted_token_id
+
+    def account_from_refresh_token(token)
+      @account = _account_from_refresh_token(token)
+    end
+
+    def _account_from_refresh_token(token)
+      account_from_key(token, account_open_status_value){|id| get_active_refresh_token_record(id)}
+    end
+
+    def get_active_refresh_token_record(id)
+      active_refresh_token_ds(id)
+    end
+
+    def active_refresh_token_ds(id)
+      refresh_token_ds_with_id(id).where(Sequel.expr(refresh_token_deadline_column) > Sequel::CURRENT_TIMESTAMP)
+    end
+
+    def refresh_token_ds_with_id(id)
+      refresh_token_ds.where(refresh_token_id_column=>id)
+    end
+
+    def refresh_token_ds
+      db[refresh_token_table]
+    end
+
+    def account_from_key(token, status_id=nil)
+      id, key = split_token(token)
+      return unless id && key
+      record = yield(id)
+      return unless actual = record.get(refresh_token_key_column)
+      return unless timing_safe_eql?(key, actual)
+      @used_token_id = id # We need to save the key to delete it later
+      account = record.get(refresh_token_account_id_column)
+      ds = account_ds(account)
+      ds = ds.where(account_status_column=>status_id) if status_id && !skip_status_checks?
+      ds.first
+    end
+
+    def remove_refresh_token_key
+      refresh_token_ds_with_id(used_token_id).delete
+    end
+
+    def split_token(token)
+      token.split(token_separator, 2)
+    end
+
+    def format_refresh_token
+      "#{inserted_token_id}#{token_separator}#{refresh_token_key_value}"
+    end
+
+    def get_refresh_token
+      generate_refresh_token_key_value
+      transaction do
+        create_refresh_token_key
+      end
+      format_refresh_token
+    end
+
+    def create_refresh_token_key
+      ds = refresh_token_ds
+      transaction do
+        @inserted_token_id = ds.insert(refresh_token_insert_hash)
+      end
+    end
+
+    def refresh_token_insert_hash
+      hash = {
+          # refresh_token_id_column=> id,
+          refresh_token_account_id_column=> account_id,
+          refresh_token_key_column=> refresh_token_key_value
+      }
+      set_deadline_value(hash, refresh_token_deadline_column, refresh_token_deadline_interval)
+      hash
+    end
+
+    def after_close_account
+      remove_refresh_token_key
+      super if defined?(super)
+    end
+
+    def generate_refresh_token_key_value
+      @refresh_token_key_value = random_key
+    end
+
+  end
+end

--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -22,7 +22,7 @@ module Rodauth
       :set_jwt_token,
       :jwt_session_hash,
       :before_refresh_token,
-      :after_refresh_token,
+      :after_refresh_token
     )
 
     route do |r|
@@ -65,8 +65,7 @@ module Rodauth
       h.merge(
           :exp => Time.now.to_i + access_token_period,
           :iat => Time.now.to_i,
-          :nbf => Time.now.to_i - 5,
-          :jti => SecureRandom.hex(10),
+          :nbf => Time.now.to_i - 5
       )
     end
 

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -1,0 +1,160 @@
+require File.expand_path("spec_helper", File.dirname(__FILE__))
+
+describe 'Rodauth login feature' do
+  it "should not have jwt refresh feature assume JWT token given during Basic/Digest authentication" do
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+    end
+    roda(:jwt) do |r|
+      rodauth.require_authentication
+      '1'
+    end
+
+    res = json_request("/jwt-refresh", :headers=>{'HTTP_AUTHORIZATION'=>'Basic foo'})
+    res.must_equal [400, {'error'=>'Please login to continue'}]
+
+    res = json_request("/", :headers=>{'HTTP_AUTHORIZATION'=>'Digest foo'})
+    res.must_equal [400, {'error'=>'Please login to continue'}]
+  end
+
+  it "should require json request content type in only json mode for rodauth endpoints only" do
+    oj = false
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+      jwt_secret '1'
+      json_response_success_key 'success'
+      only_json?{oj}
+    end
+    roda(:csrf=>false, :json=>true) do |r|
+      r.rodauth
+      rodauth.require_authentication
+      '1'
+    end
+
+    res = json_request("/", :content_type=>'application/x-www-form-urlencoded', :include_headers=>true, :method=>'GET')
+    res[1].delete('Set-Cookie')
+    res.must_equal [302, {"Content-Type"=>'text/html', "Content-Length"=>'0', "Location"=>"/login",}, []]
+
+    res = json_request("/", :content_type=>'application/vnd.api+json', :method=>'GET')
+    res.must_equal [400, ['{"error":"Please login to continue"}']]
+
+    oj = true
+
+    res = json_request("/", :content_type=>'application/x-www-form-urlencoded', :method=>'GET')
+    res.must_equal [400, ['{"error":"Please login to continue"}']]
+
+    res = json_request("/", :method=>'GET')
+    res.must_equal [400, {'error'=>'Please login to continue'}]
+
+    res = json_request("/login", :content_type=>'application/x-www-form-urlencoded', :include_headers=>true, :method=>'GET')
+    msg = "Only JSON format requests are allowed"
+    res[1].delete('Set-Cookie')
+    res.must_equal [400, {"Content-Type"=>'text/html', "Content-Length"=>msg.length.to_s}, [msg]]
+
+    json_login_with_refresh
+
+    res = json_request("/", :content_type=>'application/x-www-form-urlencoded', :include_headers=>true, :method=>'GET')
+    # res.must_equal [200, {"Content-Type"=>'text/html', "Content-Length"=>'1'}, ['1']]
+  end
+
+  it "should allow non-json requests if only_json? is false" do
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+      jwt_secret '1'
+      only_json? false
+    end
+    roda(:jwt_html) do |r|
+      r.rodauth
+      rodauth.require_authentication
+      view(:content=>'1')
+    end
+
+    login
+    page.find('#notice_flash').text.must_equal 'You have been logged in'
+  end
+
+  it "should require POST for json requests" do
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+      jwt_secret '1'
+      json_response_success_key 'success'
+    end
+    roda(:jwt) do |r|
+      r.rodauth
+    end
+
+    res = json_request("/login", :method=>'GET')
+    res.must_equal [405, {'error'=>'non-POST method used in JSON API'}]
+  end
+
+  it "should require Accept contain application/json if jwt_check_accept? is true and Accept is present" do
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+      jwt_secret '1'
+      json_response_success_key 'success'
+      jwt_check_accept? true
+    end
+    roda(:jwt) do |r|
+      r.rodauth
+    end
+
+    res = json_request("/login", :headers=>{'HTTP_ACCEPT'=>'text/html'})
+    res.must_equal [406, {'error'=>'Unsupported Accept header. Must accept "application/json" or compatible content type'}]
+
+    json_validate_login(json_request("/login", :login=>'foo@example.com', :password=>'0123456789'))
+    json_validate_login(json_request("/login", :headers=>{'HTTP_ACCEPT'=>'*/*'}, :login=>'foo@example.com', :password=>'0123456789'))
+    json_validate_login(json_request("/login", :headers=>{'HTTP_ACCEPT'=>'application/*'}, :login=>'foo@example.com', :password=>'0123456789'))
+    json_validate_login(json_request("/login", :headers=>{'HTTP_ACCEPT'=>'application/vnd.api+json'}, :login=>'foo@example.com', :password=>'0123456789'))
+  end
+
+  it "generates and refresh Refresh Tokens" do
+    rodauth do
+      enable :login, :logout, :jwt_refresh
+      jwt_secret '1'
+    end
+    roda(:jwt) do |r|
+      r.rodauth
+      rodauth.require_authentication
+      response['Content-Type'] = 'application/json'
+      {hello: 'world'}.to_json
+    end
+    # res = json_request("/")
+    # res.must_equal [400, {'error'=>'Please login to continue'}]
+
+    # We can login
+    res = json_login_with_refresh
+    refresh_token = res.last['refresh_token']
+    # Which gives us an access token which grants us access to protected resources
+    @authorization= res.last['access_token']
+    res = json_request("/")
+    res.must_equal [200, {'hello'=>'world'}]
+
+    # We can refresh our token
+    res = json_request("/jwt-refresh", :refresh_token=>refresh_token)
+    json_validate_refresh(res)
+    second_refresh_token = res.last['refresh_token']
+
+    # Which we can use to access protected resources
+    @authorization= res.last['access_token']
+    res = json_request("/")
+    res.must_equal [200, {'hello'=>'world'}]
+
+    # Subsequent refresh token is valid
+    res = json_request("/jwt-refresh", :refresh_token=>second_refresh_token)
+    json_validate_refresh(res)
+    third_refresh_token = res.last['refresh_token']
+
+    # First refresh Token is now no longer valid
+    res = json_request("/jwt-refresh", :refresh_token=>refresh_token)
+    res.must_equal [400, {"error"=>"invalid refresh token"}]
+
+    # Third refresh token is valid
+    res = json_request("/jwt-refresh", :refresh_token=>third_refresh_token)
+    json_validate_refresh(res)
+
+    # And still gives us a valid access token
+    @authorization= res.last['access_token']
+    res = json_request("/")
+    res.must_equal [200, {'hello'=>'world'}]
+  end
+end

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -116,7 +116,7 @@ describe 'Rodauth login feature' do
       r.rodauth
       rodauth.require_authentication
       response['Content-Type'] = 'application/json'
-      {hello: 'world'}.to_json
+      {'hello' => 'world'}.to_json
     end
     # res = json_request("/")
     # res.must_equal [400, {'error'=>'Please login to continue'}]

--- a/spec/migrate/001_tables.rb
+++ b/spec/migrate/001_tables.rb
@@ -38,6 +38,14 @@ Sequel.migration do
       DateTime :deadline, deadline_opts[1]
     end
 
+    # Used by the refresh token feature
+    create_table(:account_refresh_tokens) do
+      primary_key :id, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>:Bignum
+      String :key, :null=>false
+      DateTime :deadline, deadline_opts[1]
+    end
+
     # Used by the account verification feature
     create_table(:account_verification_keys) do
       foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum

--- a/spec/migrate_travis/001_tables.rb
+++ b/spec/migrate_travis/001_tables.rb
@@ -46,6 +46,14 @@ Sequel.migration do
       DateTime :deadline, deadline_opts[1]
     end
 
+    # Used by the refresh token feature
+    create_table(:account_refresh_tokens) do
+      primary_key :id, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>:Bignum
+      String :key, :null=>false
+      DateTime :deadline, deadline_opts[1]
+    end
+
     create_table(:account_verification_keys) do
       foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
       String :key, :null=>false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -194,7 +194,7 @@ class Minitest::HooksSpec
   end
 
   def json_login_with_refresh
-    res = json_login no_check: true
+    res = json_login({:no_check => true})
     json_validate_login(res)
     res
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -193,6 +193,26 @@ class Minitest::HooksSpec
     res
   end
 
+  def json_login_with_refresh
+    res = json_login no_check: true
+    json_validate_login(res)
+    res
+  end
+
+  def json_validate_login(res)
+    res.first.must_equal 200
+    res.last.keys.sort.must_equal ['access_token', 'refresh_token', 'success']
+    res.last['success'].must_equal 'You have been logged in'
+    res
+  end
+
+  def json_validate_refresh(res)
+    res.first.must_equal 200
+    res.last.keys.sort.must_equal ['access_token', 'refresh_token']
+    res
+  end
+
+
   def json_logout
     json_request("/logout").must_equal [200, {"success"=>'You have been logged out'}]
   end


### PR DESCRIPTION
I needed a short access token, with longer lived refresh token.

Refresh tokens are stored in the DB and expired on use. They are provided in the JSON body of the response on login and calls to refresh. 

This allows to run Rodauth as a standalone Authorization server, with a separate API system simply checking the validity of the short-lived access tokens.

I made one change to the existing JWT Feature. I do not think a token should be provided when the login is rejected (even if that token did not contain the account).

Tests pass on Ruby 1.8.7 to 2.4. They seem to fail for the same reason as master on jruby.