### PR TITLE
Don't provide a token when login fails

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -179,7 +179,7 @@ module Rodauth
 
     def return_json_response
       response.status ||= json_response_error_status if json_response[json_response_error_key]
-      set_jwt
+      set_jwt unless json_response[json_response_error_key]
       response['Content-Type'] ||= json_response_content_type
       response.write(request.send(:convert_to_json, json_response))
       request.halt


### PR DESCRIPTION
This change removes providing a JWT when the user attempts to sign up, and is unsuccessful.

Open question, when clearing the session, the JWT is set as well. Is this correct behaviour? 