### PR TITLE
Allow cache setting to be overridden

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -37,6 +37,7 @@ account_select :: An array of columns to select from +accounts_table+. By
                   default, selects all columns in the table.
 account_status_column :: The status id column in the account model.
 account_unverified_status_value :: The representating unverified accounts.
+cache_templates :: Whether to cache templates. True by default.
 default_redirect :: Where to redirect after most successful actions.
 invalid_field_error_status :: The response status to use for invalid field
                               value errors, 422 by default.

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -238,7 +238,7 @@ module Rodauth
       opts = Hash[template_opts].merge!(opts)
       opts[:locals] = {:value=>value, :opts=>opts}
       opts[:path] = template_path('button')
-      opts[:cache] = true
+      opts[:cache] = true unless opts.has_key?(:cache)
       opts[:cache_key] = :rodauth_button
       opts
     end

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -516,7 +516,7 @@ module Rodauth
       opts = template_opts.dup
       opts[:locals] = opts[:locals] ? opts[:locals].dup : {}
       opts[:locals][:rodauth] = self
-      opts[:cache] = true
+      opts[:cache] = true unless opts.has_key?(:cache)
       opts[:cache_key] = :"rodauth_#{page}"
 
       scope.instance_exec do

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -44,6 +44,7 @@ module Rodauth
     auth_value_method :unmatched_field_error_status, 422
     auth_value_method :unopen_account_error_status, 403
     auth_value_method :unverified_account_message, "unverified account, please verify account before logging in"
+    auth_value_method :cache_templates, true
 
     redirect(:require_login){"#{prefix}/login"}
 
@@ -238,7 +239,7 @@ module Rodauth
       opts = Hash[template_opts].merge!(opts)
       opts[:locals] = {:value=>value, :opts=>opts}
       opts[:path] = template_path('button')
-      opts[:cache] = true unless opts.has_key?(:cache)
+      opts[:cache] = cache_templates unless opts.has_key?(:cache)
       opts[:cache_key] = :rodauth_button
       opts
     end
@@ -517,7 +518,7 @@ module Rodauth
       opts = template_opts.dup
       opts[:locals] = opts[:locals] ? opts[:locals].dup : {}
       opts[:locals][:rodauth] = self
-      opts[:cache] = true unless opts.has_key?(:cache)
+      opts[:cache] = cache_templates unless opts.has_key?(:cache)
       opts[:cache_key] = :"rodauth_#{page}"
 
       scope.instance_exec do

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -235,7 +235,8 @@ module Rodauth
     end
 
     def button_opts(value, opts)
-      opts = {:locals=>{:value=>value, :opts=>opts}}
+      opts = Hash[template_opts].merge!(opts)
+      opts[:locals] = {:value=>value, :opts=>opts}
       opts[:path] = template_path('button')
       opts[:cache] = true
       opts[:cache_key] = :rodauth_button


### PR DESCRIPTION
Add's a `cache_templates` method to base, with a default value of true, allowing the caching of templates to be configurable.

Stops the clobbering of the `cache` value if provided via `template_opts`.

Uses `template_opts` as the base for `button_opts`.