### PR TITLE
Update "model instance" references

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -618,7 +618,7 @@ response :: RodaResponse instance
 scope :: Roda instance
 session :: session hash
 flash :: flash message hash
-account :: account model instance (if set by an earlier Rodauth method)
+account :: account hash (if set by an earlier Rodauth method)
 
 So if you want to log the IP address for the user during login:
 

--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -102,9 +102,9 @@ before_login :: Run arbitrary code after password has been checked, but
 before_login_attempt :: Run arbitrary code after an account has been
                         located, but before the password has been checked.
 before_rodauth :: Run arbitrary code before handling any rodauth route.
-account_from_login(login) :: Retrieve the account model instance related to the
+account_from_login(login) :: Retrieve the account hash related to the
                              given login or nil if no login matches.
-account_from_session :: Retrieve the account model instance related to the currently
+account_from_session :: Retrieve the account hash related to the currently
                         logged in session.
 account_id :: The primary key value of the current account
 account_session_value :: The primary value of the account currently stored in the

--- a/doc/create_account.rdoc
+++ b/doc/create_account.rdoc
@@ -29,7 +29,7 @@ create_account_autologin? :: Whether to autologin the user upon
 create_account_link :: HTML fragment to display with a link to the create
                        account form.
 create_account_view :: The HTML to use for the create account form.
-new_account(login) :: Instantiate a new account model instance for the
+new_account(login) :: Instantiate a new account hash for the
                       given login, without saving it.
 save_account :: Insert the account into the database, or return nil/false if that
                 was not successful.


### PR DESCRIPTION
Rodauth doesn't use model instances anymore, it uses plain hashes instead. So, we update some leftover references of "model instances".

Closes #48