### PR TITLE
Fix typo in #authenticated? docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -822,7 +822,7 @@ check_session_expiration :: (session_expiration feature) Check whether the curre
 check_single_session :: (single_session feature) Check whether the current
                         session is still the only valid session, automatically logging
                         the session out if not.
-verified_account? :: (verify_grace_period extension) Whether the account is currently
+verified_account? :: (verify_grace_period feature) Whether the account is currently
                      verified.  If false, it is because the account is allowed to
                      login as they are in the grace period.
 locked_out? :: (lockout feature) Whether the account for the current session has been

--- a/README.rdoc
+++ b/README.rdoc
@@ -819,7 +819,7 @@ logged_in_via_remember_key? :: (remember feature) Whether the current session ha
 check_session_expiration :: (session_expiration feature) Check whether the current
                             session has expired, automatically logging the session
                             out if so.
-check_single_session :: (single_session expiration) Check whether the current
+check_single_session :: (single_session feature) Check whether the current
                         session is still the only valid session, automatically logging
                         the session out if not.
 verified_account? :: (verify_grace_period extension) Whether the account is currently

--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -114,8 +114,8 @@ account_session_value :: The primary value of the account currently stored in th
 already_logged_in :: What action to take if you are already logged in and attempt
                      to access a page that only makes sense if you are not logged in.
 authenticated? :: Whether the user has been authenticated. If 2 factor authentication
-                  has not been enabled for the account, this is true only if both
-                  factors have been authenticated.
+                  has been enabled for the account, this is true only if both factors
+                  have been authenticated.
 clear_session :: Clears the current session.
 csrf_tag(path=request.path) :: The HTML fragment containing the CSRF tag to use, if any.
 function_name(name) :: The name of the database function to call.  It's passed either


### PR DESCRIPTION
Since the second part of the sentence says that both factors have to been authenticated, I think the first part meant to say "If 2 factor authentication *has* been enabled..."