### PR TITLE
replaced hard-coded string 'already an account with this login' 

### DIFF
--- a/doc/login_password_requirements_base.rdoc
+++ b/doc/login_password_requirements_base.rdoc
@@ -5,6 +5,9 @@ use a Rodauth feature that requires setting logins or passwords.
 
 == Auth Value Methods
 
+already_an_account_with_this_login_message :: The error message to display when
+                                              there already exists an account
+                                              with the same login
 login_confirm_label :: The label to use for login confirmations.
 login_confirm_param :: The parameter name to use for login confirmations.
 login_does_not_meet_requirements_message :: The error message to display when

--- a/lib/rodauth/features/change_login.rb
+++ b/lib/rodauth/features/change_login.rb
@@ -81,7 +81,7 @@ module Rodauth
       updated = nil
       raised = raises_uniqueness_violation?{updated = update_account({login_column=>login}, account_ds.exclude(login_column=>login)) == 1}
       if raised
-        @login_requirement_message = 'already an account with this login'
+        @login_requirement_message = already_an_account_with_this_login_message
       end
       updated && !raised
     end

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -103,13 +103,13 @@ module Rodauth
     def new_account(login)
       @account = _new_account(login)
     end
-    
+
     def save_account
       id = nil
       raised = raises_uniqueness_violation?{id = db[accounts_table].insert(account)}
 
       if raised
-        @login_requirement_message = 'already an account with this login'
+        @login_requirement_message = already_an_account_with_this_login_message
       end
 
       if id

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -2,6 +2,7 @@
 
 module Rodauth
   Feature.define(:login_password_requirements_base, :LoginPasswordRequirementsBase) do
+    auth_value_method :already_an_account_with_this_login_message, 'already an account with this login'
     auth_value_method :login_confirm_param, 'login-confirm'
     auth_value_method :login_minimum_length, 3
     auth_value_method :login_maximum_length, 255

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -147,7 +147,7 @@ module Rodauth
 
     def update_login(login)
       if _account_from_login(login)
-        @login_requirement_message = 'already an account with this login'
+        @login_requirement_message = already_an_account_with_this_login_message
         return false
       end
 


### PR DESCRIPTION
Replaced hard-coded string 'already an account with this login' in several features with a single configurable `auth_value_method` in 'base' feature.

Some end-of-line spaces were automatically removed by emacs.

Added rules  to `.gitignore` to ignore files often created by a development environment.