### PR TITLE
Implemented 'login return to' feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== master
+
+* Add already_an_account_with_this_login_message configuration method (1gor) (#54)
+
 === 1.19.1 (2018-11-16)
 
 * Support rotp 4 in the otp feature (jeremyevans)

--- a/doc/login_return_to.rdoc
+++ b/doc/login_return_to.rdoc
@@ -1,0 +1,9 @@
+= Documentation for Login Return To Feature
+
+The login return to feature allows to remember the requested protected url and
+to redirect back to it after successful login. It depends on login feature.
+
+== Auth Value Methods
+
+login_return_to_session_key :: session key name that holds the
+                               requested url, defaults to 'return_to'.

--- a/lib/rodauth/features/login_return_to.rb
+++ b/lib/rodauth/features/login_return_to.rb
@@ -1,0 +1,26 @@
+# frozen-string-literal: true
+
+module Rodauth
+  Feature.define(:login_return_to, :LoginReturnTo) do
+    depends :base, :login
+
+    auth_value_method :login_return_to_session_key, 'return_to'
+
+    def login_required
+      session[login_return_to_session_key] = request.fullpath
+      super
+    end
+
+    def clear_session
+      return_to = session[login_return_to_session_key]
+      super
+      session[login_return_to_session_key] = return_to
+    end
+
+    def login_redirect
+      return_to = scope.session.delete(login_return_to_session_key)
+      return_to || super
+    end
+
+  end
+end

--- a/spec/login_return_to_spec.rb
+++ b/spec/login_return_to_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path("spec_helper", File.dirname(__FILE__))
+describe 'Rodauth login return to feature' do
+
+  it "should remember requested url and return to it after login" do
+    rodauth{enable :login_return_to}
+    roda do |r|
+      r.rodauth
+      r.get "target" do
+        rodauth.require_login
+        view :content=>"Target Page"
+      end
+      r.root{view :content=>"Logged In"}
+    end
+
+    visit '/target'
+    page.title.must_equal 'Login'
+    fill_in 'Login', :with=>"foo@example.com"
+    fill_in 'Password', :with=>'0123456789'
+    click_button 'Login'
+    page.current_path.must_equal '/target'
+    page.find('#notice_flash').text.must_equal 'You have been logged in'
+    page.html.must_include("Target Page")
+
+  end
+end


### PR DESCRIPTION
This feature implements a common use case when a user navigates to a protected url, is shown a login page, logs in successfully and expects then to be shown the initially requested page.

Without this feature a user wishing to reach, for example, the protected "/profile" page will be presented with a login form and then sent to the home page rather than to his target url. 