### PR TITLE
Disable autocomplete on OTP Auth Code input

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -167,7 +167,7 @@ module Rodauth
         value = opts.fetch(:value){scope.h param(param)}
       end
 
-      "<input #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"form-control#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\"/> #{formatted_field_error(param)}"
+      "<input #{opts[:attr]} #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"form-control#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\"/> #{formatted_field_error(param)}"
     end
 
     def default_field_attributes

--- a/spec/two_factor_spec.rb
+++ b/spec/two_factor_spec.rb
@@ -80,6 +80,8 @@ describe 'Rodauth OTP feature' do
     login
     page.current_path.must_equal '/otp-auth'
 
+    page.find_by_id('otp-auth-code')[:autocomplete].must_equal 'off'
+
     %w'/otp-disable /recovery-codes /otp-setup /sms-setup /sms-disable /sms-confirm'.each do |path|
       visit path
       page.find('#error_flash').text.must_equal 'You need to authenticate via 2nd factor before continuing.'

--- a/templates/otp-auth-code-field.str
+++ b/templates/otp-auth-code-field.str
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="col-sm-4 control-label" for="otp-auth-code">#{rodauth.otp_auth_label}#{rodauth.input_field_label_suffix}</label>
   <div class="col-sm-3">
-    #{rodauth.input_field_string(rodauth.otp_auth_param, 'otp-auth-code', :value=>'')}
+    #{rodauth.input_field_string(rodauth.otp_auth_param, 'otp-auth-code', :value=>'', :attr=>'autocomplete="off"' )}
   </div>
 </div>


### PR DESCRIPTION
This code is likely input from a separate device and any previous values are unnecessary noise. 

Adds an `attr` option to the `opts` hash passed to `input_field_string`, allowing us to pass arbitrary attributes.