### PR TITLE
Fix disallow password reuse feature when not using verify_account

### DIFF
--- a/lib/rodauth/features/disallow_password_reuse.rb
+++ b/lib/rodauth/features/disallow_password_reuse.rb
@@ -70,7 +70,7 @@ module Rodauth
     end
 
     def after_create_account
-      if account_password_hash_column && !respond_to?(:verify_account_set_password?) || !verify_account_set_password?
+      if account_password_hash_column && !(respond_to?(:verify_account_set_password?) && verify_account_set_password?)
         add_previous_password_hash(password_hash(param(password_param)))
       end
       super if defined?(super)


### PR DESCRIPTION
When account_password_hash_column is unset and the verify account feature is not loaded, verify_account_set_password? is called raising a NoMethodError.