### PR TITLE
Extract email delivering into a method

### DIFF
--- a/doc/email_base.rdoc
+++ b/doc/email_base.rdoc
@@ -26,3 +26,4 @@ email_to :: The email address to send emails to, by default the login of the
             current account.
 create_email(subject, body) :: Return a Mail::Message instance with the given subject
                                and body.
+send_email(email) :: Deliver a given Mail::Message instance.

--- a/lib/rodauth/features/change_password_notify.rb
+++ b/lib/rodauth/features/change_password_notify.rb
@@ -17,7 +17,7 @@ module Rodauth
     private
 
     def send_password_changed_email
-      create_password_changed_email.deliver!
+      send_email(create_password_changed_email)
     end
 
     def create_password_changed_email

--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -135,7 +135,7 @@ module Rodauth
     end
 
     def send_email_auth_email
-      create_email_auth_email.deliver!
+      send_email(create_email_auth_email)
     end
 
     def email_auth_email_link

--- a/lib/rodauth/features/email_base.rb
+++ b/lib/rodauth/features/email_base.rb
@@ -15,7 +15,8 @@ module Rodauth
 
     auth_methods(
       :create_email,
-      :email_to
+      :email_to,
+      :send_email
     )
 
     def post_configure
@@ -24,6 +25,10 @@ module Rodauth
     end
 
     private
+
+    def send_email(email)
+      email.deliver!
+    end
 
     def create_email(subject, body)
       create_email_to(email_to, subject, body)

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -218,7 +218,7 @@ module Rodauth
 
     def send_unlock_account_email
       @unlock_account_key_value = get_unlock_account_key
-      create_unlock_account_email.deliver!
+      send_email(create_unlock_account_email)
     end
 
     def unlock_account_email_link

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -179,7 +179,7 @@ module Rodauth
     end
 
     def send_reset_password_email
-      create_reset_password_email.deliver!
+      send_email(create_reset_password_email)
     end
 
     def reset_password_email_link

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -201,7 +201,7 @@ module Rodauth
     end
 
     def send_verify_account_email
-      create_verify_account_email.deliver!
+      send_email(create_verify_account_email)
     end
 
     def verify_account_email_link

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -118,7 +118,7 @@ module Rodauth
     end
 
     def send_verify_login_change_email(login)
-      create_verify_login_change_email(login).deliver!
+      send_email(create_verify_login_change_email(login))
     end
 
     def verify_login_change_email_link


### PR DESCRIPTION
I'm working on a `rodauth-rails` gem that integrates Rodauth with Rails. One of the things I wanted the Rails integration to do is to automatically deliver all emails through ActionMailer. A benefit of this is that in development Rails rescues delivery failures and prints the message in the logs, which is convenient when you don't have another delivery method configured yet.

To achieve this, I need two things:

* create the email through an `ActionMailer::Base` subclass (which returns a `ActionMailer::MessageDelivery` object, a delegate to `Mail::Message`)
* call `#deliver_(now|later)` on the resulting object (which internally ends up calling `Mail::Message#deliver!`, but wraps it in a block that rescues delivery failures if so configured)

```rb
class Rodauth::Rails::Mailer < ActionMailer::Base
  def rodauth(**options)
    mail(**options)
  end
end
```
```rb
email = Rodauth::Rails::Mailer.rodauth(to: "....", from: "...", subject: "...", body: "...")
email.deliver_now
```

I decided it would make sense for my Rails plugin to override `#create_email`:

```rb
def create_email(subject, body)
  Rodauth::Rails::Mailer.rodauth(to: email_to, from: email_from, subject: subject, body: body)
end
```

However, the problem is that the `.deliver!` call is currently hardcoded in individual features. What I need is that this method is extracted in a method, so that I can override it and call `#deliver_(now|later)`:

```rb
def send_email(email)
  email.deliver_now
end
```

This is what this PR does. I think this might be useful outside of my use case, as for example it's possible to specify the delivery handler per message, which could now potentially be used in another Rodauth plugin (i.e. specify delivery handler ad-hoc without overriding global `Mail` settings).