### PR TITLE
Add *_path and *_url counterparts to *_route methods

### DIFF
--- a/doc/change_login.rdoc
+++ b/doc/change_login.rdoc
@@ -27,4 +27,6 @@ before_change_login_route :: Run arbitrary code before handling a change login r
 change_login(login) :: Change the users login to the given login, or
                        return nil/false if the login cannot be changed to
                        the given login.
+change_login_path :: The relative URL to the change login action.
+change_login_url :: The absolute URL to the change login action.
 change_login_view :: The HTML to use for the change login form.

--- a/doc/change_password.rdoc
+++ b/doc/change_password.rdoc
@@ -24,6 +24,8 @@ change_password_route :: The route to the change password action. Defaults to
 after_change_password :: Run arbitrary code after successful password change.
 before_change_password :: Run arbitrary code before changing the password for an account.
 before_change_password_route :: Run arbitrary code before handling a change password route.
+change_password_path :: The relative URL to the change password action.
+change_password_url :: The absolute URL to the change password action.
 change_password_view :: The HTML to use for the change password form.
 invalid_previous_password_message :: The message to use when the previous password was
                                      incorrect.  Defaults to invalid_password_message.

--- a/doc/close_account.rdoc
+++ b/doc/close_account.rdoc
@@ -26,6 +26,8 @@ before_close_account :: Run arbitrary code before closing an account.
 before_close_account_route :: Run arbitrary code before handling a close account route.
 close_account :: Close the account, by default setting the account status
                  to closed.
+close_account_path :: The relative URL to the close account action.
+close_account_url :: The absolute URL to the close account action.
 close_account_view :: The HTML to use for the close account form.
 delete_account :: If +delete_account_on_close?+ is true, delete the account
                   when closing it.

--- a/doc/confirm_password.rdoc
+++ b/doc/confirm_password.rdoc
@@ -21,4 +21,6 @@ after_confirm_password :: Run arbitrary code after successful confirmation of pa
 before_confirm_password :: Run arbitrary code before setting that the password has been confirmed.
 confirm_password :: Run arbitrary code on correct password confirmation.
 before_confirm_password_route :: Run arbitrary code before handling the password confirmation route.
+confirm_password_path :: The relative URL to the confirm password form.
+confirm_password_url :: The absolute URL to the confirm password form.
 confirm_password_view :: The HTML to use for the confirm password form.

--- a/doc/create_account.rdoc
+++ b/doc/create_account.rdoc
@@ -28,6 +28,8 @@ create_account_autologin? :: Whether to autologin the user upon
                              accounts.
 create_account_link :: HTML fragment to display with a link to the create
                        account form.
+create_account_path :: The relative URL to the create account action.
+create_account_url :: The absolute URL to the create account action.
 create_account_view :: The HTML to use for the create account form.
 new_account(login) :: Instantiate a new account hash for the
                       given login, without saving it.

--- a/doc/email_auth.rdoc
+++ b/doc/email_auth.rdoc
@@ -44,7 +44,11 @@ email_auth_email_body :: The body to use for the email auth email.
 email_auth_email_link :: The link to the email auth form in the email auth email.
 email_auth_key_insert_hash :: The hash to insert into the email auth keys table.
 email_auth_key_value :: The email auth key for the current account.
+email_auth_path :: The relative URL to the email auth action.
 email_auth_request_form :: The HTML to use for a form to request an email auth email, shown on the login page after the user submits their login, if +force_email_auth?+ is false.
+email_auth_request_path :: The relative URL to the email auth request action.
+email_auth_request_url :: The absolute URL to the email auth request action.
+email_auth_url :: The absolute URL to the email auth action.
 email_auth_view :: The HTML to use for the email auth form.
 get_email_auth_key(id) :: Get the email auth key for the given account id from the database.
 get_email_auth_email_last_sent :: Get the last time an email auth email is sent, or nil if there is no last sent time.

--- a/doc/lockout.rdoc
+++ b/doc/lockout.rdoc
@@ -38,7 +38,7 @@ unlock_account_request_notice_flash :: The flash notice to display upon successf
 unlock_account_request_redirect :: Where to redirect after account unlock email is sent.
 unlock_account_request_route :: The route to the unlock account request action.  Defaults to +unlock-account-request+.
 unlock_account_requires_password? :: Whether a password is required when unlocking accounts, false by default.  May want to set to true if not allowing password resets.
-unlock_account_route :: Alias for lockout_route.
+unlock_account_route :: The route to the unlock account action.
 unlock_account_session_key :: The key in the session to hold the unlock account key temporarily.
 unlock_account_skip_resend_email_within :: The number of seconds before sending another unlock account email, if +account_lockouts_email_last_sent_column+ is set.
 
@@ -65,5 +65,9 @@ unlock_account_email_body :: The body to use for the unlock account email.
 unlock_account_email_link :: The link to the unlock account form to include in the unlock account email.
 unlock_account :: Unlock the account.
 unlock_account_key :: The unlock account key for the current account.
+unlock_account_path :: The relative URL to the unlock account action.
+unlock_account_request_path :: The relative URL to the unlock account request action.
+unlock_account_request_url :: The absolute URL to the unlock account request action.
 unlock_account_request_view :: The HTML to use for the unlock account request form.
+unlock_account_url :: The absolute URL to the unlock account action.
 unlock_account_view :: The HTML to use for the unlock account form.

--- a/doc/login.rdoc
+++ b/doc/login.rdoc
@@ -19,4 +19,6 @@ use_multi_phase_login? :: Whether to ask for login first, and only ask for passw
 == Auth Methods
 
 before_login_route :: Run arbitrary code before handling a login route.
+login_path :: The relative URL to the login action.
+login_url :: The absolute URL to the login action.
 login_view :: The HTML to use for the login form.

--- a/doc/logout.rdoc
+++ b/doc/logout.rdoc
@@ -18,4 +18,6 @@ after_logout :: Run arbitrary code after logout.
 before_logout :: Run arbitrary code before logout.
 before_logout_route :: Run arbitrary code before handling a logout route.
 logout :: Log the user out, by default clearing the session.
+logout_path :: The relative URL to the logout action.
+logout_url :: The absolute URL to the logout action.
 logout_view :: The HTML to use for the logout form.

--- a/doc/otp.rdoc
+++ b/doc/otp.rdoc
@@ -64,7 +64,11 @@ before_otp_disable :: Run arbitrary code before OTP authentication disabling.
 before_otp_disable_route :: Run arbitrary code before handling an OTP authentication disable route.
 otp :: The object used for verifying OTP authentication attempts.
 otp_add_key(secret) :: Add an OTP key for the current account with the given secret.
+otp_auth_path :: The relative URL to the OTP authentication action.
+otp_auth_url :: The absolute URL to the OTP authentication action.
 otp_auth_view :: The HTML to use for the OTP authentication form.
+otp_disable_path :: The relative URL to the OTP disable action.
+otp_disable_url :: The absolute URL to the OTP disable action.
 otp_disable_view :: The HTML to use for the OTP disable form.
 otp_exists? :: Whether the current account has setup OTP.
 otp_key :: The stored OTP secret for the account.
@@ -76,6 +80,8 @@ otp_qr_code :: The QR code containing the otp_provisioning_uri, by default an SV
 otp_record_authentication_failure :: Record an OTP authentication failure.
 otp_remove :: Removes all stored OTP data for the current account.
 otp_remove_auth_failures :: Removes OTP authentication failures for the current account, used after successful OTP authentication.
+otp_setup_path :: The relative URL to the OTP setup action.
+otp_setup_url :: The absolute URL to the OTP setup action.
 otp_setup_view :: The HTML to use for the form to setup OTP authentication.
 otp_tmp_key(secret) :: Set the secret to use for the OTP key.
 otp_update_last_use :: Update the last time OTP authentication was successful for the account.  Return true if the authentication should be allowed, or false if it should not be allowed because the last authentication was too recent and indicates the possible reuse of a TOTP authentication code.

--- a/doc/recovery_codes.rdoc
+++ b/doc/recovery_codes.rdoc
@@ -47,7 +47,11 @@ before_recovery_codes_route :: Run arbitrary code before handling view/add recov
 before_view_recovery_codes :: Run arbitrary code before viewing recovery codes.
 can_add_recovery_codes? :: Whether the current account can add more recovery codes.
 new_recovery_code :: A new recovery code to insert into the recovery codes table.
+recovery_auth_path :: The relative URL to the recovery code authentication action.
+recovery_auth_url :: The absolute URL to the recovery code authentication action.
 recovery_auth_view :: The HTML to use for the form to authenticate via a recovery code.
 recovery_code_match?(code) :: Whether the given code matches any of the existing recovery_codes.
 recovery_codes :: An array containing all valid recovery codes for the current account.
+recovery_codes_path :: The relative URL to the view recovery codes action.
+recovery_codes_url :: The absolute URL to the view recovery codes action.
 recovery_codes_view :: The HTML to use for the form to view recovery codes.

--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -94,6 +94,8 @@ logged_in_via_remember_key? :: Whether the current session was logged in via
 remember_key_value :: The current value of the remember key/token.
 remember_login :: Set the cookie containing the remember token, so that future
                   sessions will be autologged in.
+remember_path :: The relative URL to the change remember settings action.
+remember_url :: The absolute URL to the change remember settings action.
 remember_view :: The HTML to use for the change remember settings form.
 remove_remember_key(id_value=account_id) :: Delete the related remember key from
                                             the database.

--- a/doc/reset_password.rdoc
+++ b/doc/reset_password.rdoc
@@ -55,7 +55,11 @@ reset_password_email_body :: The body to use for the reset password email.
 reset_password_email_link :: The link to the reset password form in the reset password email.
 reset_password_key_insert_hash :: The hash to insert into the reset password keys table.
 reset_password_key_value :: The reset password key for the current account.
+reset_password_path :: The relative URL to the reset password action.
+reset_password_request_path :: The relative URL to the reset password request action.
+reset_password_request_url :: The absolute URL to the reset password request action.
 reset_password_request_view :: The HTML to use for the reset password request form.
+reset_password_url :: The absolute URL to the reset password action.
 reset_password_view :: The HTML to use for the reset password form.
 send_reset_password_email :: Send the reset password email.
 set_reset_password_email_last_sent :: Set the last time a reset password email is sent.

--- a/doc/sms_codes.rdoc
+++ b/doc/sms_codes.rdoc
@@ -94,15 +94,21 @@ before_sms_request_route :: Run arbitrary code before handling SMS request route
 before_sms_setup :: Run arbitrary code before setting up SMS authentication.
 before_sms_setup_route :: Run arbitrary code before handling SMS setup route.
 sms_auth_message(code) :: The SMS message to use for the given authentication code.
+sms_auth_path :: The relative URL to the SMS authentication action.
+sms_auth_url :: The absolute URL to the SMS authentication action.
 sms_auth_view :: The HTML to use for the form to authenticate via SMS code.
 sms_available? :: Whether SMS authentication is ready for use.
 sms_code_issued_at :: The timestamp the current SMS code was issued at.
 sms_code_match?(code) :: Whether there is an active SMS authentication code for the current account and the given code matches it.
 sms_confirm_message(code) :: The SMS message to use for the given confirmation code.
+sms_confirm_path :: The relative URL to the SMS setup confirmation action.
+sms_confirm_url :: The absolute URL to the SMS setup confirmation action.
 sms_confirm_view :: The HTML to use for the form to authenticate via SMS code.
 sms_confirmation_match?(code) :: Whether there is an active SMS confirmation code for the current account and the given code matches it.
 sms_current_auth? :: Whether there is a active SMS authentication code for the current account.
 sms_disable :: Action to take to disable SMS authentication for the account.
+sms_disable_path :: The relative URL to the SMS authentication disable action.
+sms_disable_url :: The absolute URL to the SMS authentication disable action.
 sms_disable_view :: The HTML to use for the form to disable SMS authentication.
 sms_failures :: The number of SMS authentication failures since the last successfully SMS authentication for this account.
 sms_locked_out? :: Whether SMS authentication has been locked out for the current account.
@@ -112,10 +118,14 @@ sms_new_confirm_code :: A new SMS confirmation code that can be used for the acc
 sms_normalize_phone(phone) :: A normalized version of the given phone number, by default removing everything except 0-9.
 sms_record_failure :: Record an SMS authentication failure for the current account.
 sms_remove_failures :: Reset the SMS authentication failure counter for the current account, used after a successful SMS authentication.
+sms_request_path :: The relative URL to the SMS authentication code request action.
+sms_request_url :: The absolute URL to the SMS authentication code request action.
 sms_request_view :: The HTML to use for the form to request an SMS authentication code.
 sms_send(phone, message) :: Send the given message to the given phone number via SMS.  By default a NotImplementedError is raised, this is the only method that must be overridden. 
 sms_set_code(code) :: Set the SMS authentication code for the current account to the given code.  The code can be +nil+ to specify that no SMS authentication code is currently valid.
 sms_setup :: Setup SMS authentication for the current account.
 sms_setup? :: Whether SMS authentication has been setup and confirmed for the current account.
+sms_setup_path :: The relative URL to the SMS authentication setup action.
+sms_setup_url :: The absolute URL to the SMS authentication setup action.
 sms_setup_view :: The HTML to use for the form to setup SMS authentication.
 sms_valid_phone?(phone) :: Whether the given phone number is a valid phone number.

--- a/doc/verify_account.rdoc
+++ b/doc/verify_account.rdoc
@@ -60,4 +60,8 @@ verify_account_email_body :: The body to use for the verify account email.
 verify_account_email_link :: The link to the verify account form in the verify account email.
 verify_account_key_insert_hash :: The hash to insert into the verify account keys table.
 verify_account_key_value :: The value of the verify account key.
+verify_account_path :: The relative URL to the verify account action.
+verify_account_resend_path :: The relative URL to the verify account resend action.
+verify_account_resend_url :: The absolute URL to the verify account resent action.
+verify_account_url :: The absolute URL to the verify account action.
 verify_account_view :: The HTML to use for the verify account form.

--- a/doc/verify_login_change.rdoc
+++ b/doc/verify_login_change.rdoc
@@ -53,4 +53,6 @@ verify_login_change_key_insert_hash(login) :: The hash to insert into the verify
 verify_login_change_key_value :: The value of the verify login change key.
 verify_login_change_new_login :: The new login to use when the login change is verified.
 verify_login_change_old_login :: The old login to display in the verify login change email.
+verify_login_change_path :: The relative URL to the verify login change action.
+verify_login_change_url :: The absolute URL to the verify login change action.
 verify_login_change_view :: The HTML to use for the verify login change form.

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -101,11 +101,15 @@ module Rodauth
     attr_accessor :configuration
 
     def route(name=feature_name, default=name.to_s.tr('_', '-'), &block)
-      auth_value_method "#{name}_route", default
+      route_meth = :"#{name}_route"
+      auth_value_method route_meth, default
+
+      define_method(:"#{name}_path") { route_path(send(route_meth)) }
+      define_method(:"#{name}_url") { route_url(send(route_meth)) }
+      auth_methods :"#{name}_path", :"#{name}_url"
 
       handle_meth = :"handle_#{name}"
       internal_handle_meth = :"_#{handle_meth}"
-      route_meth = :"#{name}_route"
       before route_meth
 
       unless block.arity == 1

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -55,7 +55,7 @@ module Rodauth
     auth_value_method :unopen_account_error_status, 403
     auth_value_method :unverified_account_message, "unverified account, please verify account before logging in"
 
-    redirect(:require_login){"#{prefix}/login"}
+    redirect(:require_login){login_path}
 
     auth_value_methods(
       :db,
@@ -385,6 +385,14 @@ module Rodauth
 
     def redirect(path)
       request.redirect(path)
+    end
+
+    def route_path(route)
+      "#{prefix}/#{route}"
+    end
+
+    def route_url(route)
+      "#{request.base_url}#{route_path(route)}"
     end
 
     def transaction(opts={}, &block)

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -89,7 +89,7 @@ module Rodauth
     end
 
     def create_account_link
-      "<p><a href=\"#{prefix}/#{create_account_route}\">Create a New Account</a></p>"
+      "<p><a href=\"#{create_account_path}\">Create a New Account</a></p>"
     end
 
     def login_form_footer

--- a/lib/rodauth/features/email_base.rb
+++ b/lib/rodauth/features/email_base.rb
@@ -51,7 +51,7 @@ module Rodauth
     end
 
     def token_link(route, param, key)
-      "#{request.base_url}#{prefix}/#{route}?#{param}=#{account_id}#{token_separator}#{convert_email_token_key(key)}"
+      "#{route_url(route)}?#{param}=#{account_id}#{token_separator}#{convert_email_token_key(key)}"
     end
 
     def convert_email_token_key(key)

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -223,11 +223,11 @@ module Rodauth
     end
 
     def two_factor_need_setup_redirect
-      "#{prefix}/#{otp_setup_route}"
+      otp_setup_path
     end
 
     def two_factor_auth_required_redirect
-      "#{prefix}/#{otp_auth_route}"
+      otp_auth_path
     end
 
     def two_factor_remove

--- a/lib/rodauth/features/password_expiration.rb
+++ b/lib/rodauth/features/password_expiration.rb
@@ -8,7 +8,7 @@ module Rodauth
     error_flash "Your password cannot be changed yet", 'password_not_changeable_yet'
 
     redirect :password_not_changeable_yet 
-    redirect(:password_change_needed){"#{prefix}/#{change_password_route}"}
+    redirect(:password_change_needed){change_password_path}
 
     auth_value_method :allow_password_change_after, -86400
     auth_value_method :require_password_change_after, 90*86400

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -23,8 +23,8 @@ module Rodauth
 
     notice_flash "Additional authentication recovery codes have been added.", 'recovery_codes_added'
 
-    redirect(:recovery_auth){"#{prefix}/#{recovery_auth_route}"}
-    redirect(:add_recovery_codes){"#{prefix}/#{recovery_codes_route}"}
+    redirect(:recovery_auth){recovery_auth_path}
+    redirect(:add_recovery_codes){recovery_codes_path}
 
     loaded_templates %w'add-recovery-codes recovery-auth recovery-codes password-field'
     view 'add-recovery-codes', 'Authentication Recovery Codes', 'add_recovery_codes'
@@ -146,7 +146,7 @@ module Rodauth
     end
 
     def otp_auth_form_footer
-      "#{super if defined?(super)}<p><a href=\"#{recovery_auth_route}\">Authenticate using recovery code</a></p>"
+      "#{super if defined?(super)}<p><a href=\"#{recovery_auth_path}\">Authenticate using recovery code</a></p>"
     end
 
     def otp_lockout_redirect

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -197,7 +197,7 @@ module Rodauth
     end
 
     def reset_password_request_link
-      "<p><a href=\"#{prefix}/#{reset_password_request_route}\">Forgot Password?</a></p>"
+      "<p><a href=\"#{reset_password_request_path}\">Forgot Password?</a></p>"
     end
 
     def set_reset_password_email_last_sent

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -45,10 +45,10 @@ module Rodauth
     redirect :sms_already_setup
     redirect :sms_confirm
     redirect :sms_disable
-    redirect(:sms_auth){"#{prefix}/#{sms_auth_route}"}
-    redirect(:sms_needs_confirmation){"#{prefix}/#{sms_confirm_route}"}
-    redirect(:sms_needs_setup){"#{prefix}/#{sms_setup_route}"}
-    redirect(:sms_request){"#{prefix}/#{sms_request_route}"}
+    redirect(:sms_auth){sms_auth_path}
+    redirect(:sms_needs_confirmation){sms_confirm_path}
+    redirect(:sms_needs_setup){sms_setup_path}
+    redirect(:sms_request){sms_request_path}
     redirect(:sms_lockout){_two_factor_auth_required_redirect}
 
     loaded_templates %w'sms-auth sms-confirm sms-disable sms-request sms-setup sms-code-field password-field'
@@ -311,7 +311,7 @@ module Rodauth
     end
 
     def otp_auth_form_footer
-      "#{super if defined?(super)}#{"<p><a href=\"#{sms_request_route}\">Authenticate using SMS code</a></p>" if sms_available?}"
+      "#{super if defined?(super)}#{"<p><a href=\"#{sms_request_path}\">Authenticate using SMS code</a></p>" if sms_available?}"
     end
 
     def otp_lockout_redirect

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -225,7 +225,7 @@ module Rodauth
     end
 
     def verify_account_resend_link
-      "<p><a href=\"#{prefix}/#{verify_account_resend_route}\">Resend Verify Account Information</a></p>"
+      "<p><a href=\"#{verify_account_resend_path}\">Resend Verify Account Information</a></p>"
     end
 
     def create_account_set_password?


### PR DESCRIPTION
Having a relative or absolute URL to the action is useful when redirecting or displaying links. They are also used in a few places inside the Rodauth codebase, which would be useful to DRY up.

So we add `*_path` and `*_url` counterparts to each `*_route` method, which return relative and absolute URL to the route respectively.

```rb
login_route #=> "login"
login_path  #=> "<prefix>/login"
login_url   #=> "https://example.com<prefix>/login"
```