### PR TITLE
Add #valid_login_entered? method for multi phase login

### DIFF
--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -150,7 +150,7 @@ module Rodauth
 
     def login_form_footer
       footer = super
-      footer += @email_auth_request_form if @email_auth_request_form
+      footer += email_auth_request_form if valid_login_entered?
       footer
     end
 
@@ -166,9 +166,8 @@ module Rodauth
         redirect email_auth_email_sent_redirect
       else
         # If the account has a password hash, allow password login, but
-        # show form below to also login via email link.
+        # we will show form below to also login via email link.
         super
-        @email_auth_request_form = email_auth_request_form
       end
     end
 

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -69,12 +69,16 @@ module Rodauth
 
     def skip_login_field_on_login?
       return false unless use_multi_phase_login?
-      @valid_login_entered
+      valid_login_entered?
     end
 
     def skip_password_field_on_login?
       return false unless use_multi_phase_login?
-      @valid_login_entered != true
+      !valid_login_entered?
+    end
+
+    def valid_login_entered?
+      @valid_login_entered
     end
 
     def login_hidden_field

--- a/spec/email_auth_spec.rb
+++ b/spec/email_auth_spec.rb
@@ -164,6 +164,13 @@ describe 'Rodauth email auth feature' do
     fill_in 'Login', :with=>'foo@example.com'
     click_button 'Login'
     page.html.must_include 'Send Login Link Via Email'
+
+    fill_in 'Password', :with=>'012345678'
+    click_button 'Login'
+    page.find('#error_flash').text.must_equal "There was an error logging in"
+    page.html.must_include("invalid password")
+    page.html.must_include 'Send Login Link Via Email'
+
     fill_in 'Password', :with=>'0123456789'
     click_button 'Login'
     page.current_path.must_equal '/'


### PR DESCRIPTION
When using the email_auth feature, we want to display the option to authentication via email when the user has entered a valid login during multi phase login.

By default, the email_auth feature overrides `#login_form_footer` to add the form for requesting email authentication. However, in my case I'm rewriting Rodauth views in Rails, and don't want to use Rodauth's view helpers such as `#login_form_footer` (I want all HTML to be contained in views).

So, I added the `#valid_login_entered?` method that reads the instance variable, which can then be called in views like this to display the email auth request form on the login page:

```rb
# ... login form ...

if rodauth.valid_login_entered?
  rodauth.email_auth_request_form
end
```

We also get rid of the `@email_auth_request_form` variable, which doesn't seem to be necessary (but I could be wrong). This changes the behaviour to display the email auth request form even when the user has entered both login and password, but the password was invalid, which I think is desirable (the user might have forgotten their password, so it's useful for them to see the alternative of email authentication).
