### PR TITLE
Reuse #login_hidden_field method

### DIFF
--- a/templates/reset-password-request.str
+++ b/templates/reset-password-request.str
@@ -2,6 +2,6 @@
   #{rodauth.reset_password_request_additional_form_tags}
   #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.reset_password_request_route}")}
   #{rodauth.reset_password_explanatory_text}
-  #{(login = rodauth.param_or_nil(rodauth.login_param)) ? "<input type=\"hidden\" name=\"#{rodauth.login_param}\" value=\"#{h login}\"/>" : rodauth.render('login-field')}
+  #{rodauth.param_or_nil(rodauth.login_param) ? rodauth.login_hidden_field : rodauth.render('login-field')}
   #{rodauth.button(rodauth.reset_password_request_button)}
 </form>

--- a/templates/unlock-account-request.str
+++ b/templates/unlock-account-request.str
@@ -1,7 +1,7 @@
 <form action="#{rodauth.prefix}/#{rodauth.unlock_account_request_route}" method="post" class="rodauth form-horizontal" role="form" id="unlock-account-request-form">
   #{rodauth.unlock_account_request_additional_form_tags}
   #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.unlock_account_request_route}")}
-  <input type="hidden" name="#{rodauth.login_param}" value="#{h rodauth.param(rodauth.login_param)}"/>
+  #{rodauth.login_hidden_field}
   #{rodauth.unlock_account_request_explanatory_text}
   <input type="submit" class="btn btn-primary inline" value="#{rodauth.unlock_account_request_button}"/>
 </form>

--- a/templates/verify-account-resend.str
+++ b/templates/verify-account-resend.str
@@ -2,6 +2,6 @@
   #{rodauth.verify_account_resend_additional_form_tags}
   #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.verify_account_resend_route}")}
   #{rodauth.verify_account_resend_explanatory_text}
-  #{(login = rodauth.param_or_nil(rodauth.login_param)) ? "<input type=\"hidden\" name=\"#{rodauth.login_param}\" value=\"#{h login}\"/>" : rodauth.render('login-field')}
+  #{rodauth.param_or_nil(rodauth.login_param) ? rodauth.login_hidden_field : rodauth.render('login-field')}
   #{rodauth.button(rodauth.verify_account_resend_button)}
 </form>


### PR DESCRIPTION
I noticed the "email-auth-request-form" and "login-display" templates use the `#login_hidden_field` method, while other templates that use a login hidden field enter the HTML manually. This changes other templates to also use the `#login_hidden_field` method for consistency.
