### PR TITLE
Use *_path methods in templates

### DIFF
--- a/templates/email-auth-request-form.str
+++ b/templates/email-auth-request-form.str
@@ -1,6 +1,6 @@
-<form action="#{rodauth.prefix}/#{rodauth.email_auth_request_route}" method="post" class="rodauth form-horizontal" role="form" id="email-auth-request-form">
+<form action="#{rodauth.email_auth_request_path}" method="post" class="rodauth form-horizontal" role="form" id="email-auth-request-form">
   #{rodauth.email_auth_request_additional_form_tags}
-  #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.email_auth_request_route}")}
+  #{rodauth.csrf_tag(rodauth.email_auth_request_path)}
   #{rodauth.login_hidden_field}
   #{rodauth.button(rodauth.email_auth_request_button)}
 </form>

--- a/templates/reset-password-request.str
+++ b/templates/reset-password-request.str
@@ -1,6 +1,6 @@
-<form action="#{rodauth.prefix}/#{rodauth.reset_password_request_route}" method="post" class="rodauth form-horizontal" role="form" id="reset-password-request-form">
+<form action="#{rodauth.reset_password_request_path}" method="post" class="rodauth form-horizontal" role="form" id="reset-password-request-form">
   #{rodauth.reset_password_request_additional_form_tags}
-  #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.reset_password_request_route}")}
+  #{rodauth.csrf_tag(rodauth.reset_password_request_path)}
   #{rodauth.reset_password_explanatory_text}
   #{rodauth.param_or_nil(rodauth.login_param) ? rodauth.login_hidden_field : rodauth.render('login-field')}
   #{rodauth.button(rodauth.reset_password_request_button)}

--- a/templates/unlock-account-request.str
+++ b/templates/unlock-account-request.str
@@ -1,6 +1,6 @@
-<form action="#{rodauth.prefix}/#{rodauth.unlock_account_request_route}" method="post" class="rodauth form-horizontal" role="form" id="unlock-account-request-form">
+<form action="#{rodauth.unlock_account_request_path}" method="post" class="rodauth form-horizontal" role="form" id="unlock-account-request-form">
   #{rodauth.unlock_account_request_additional_form_tags}
-  #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.unlock_account_request_route}")}
+  #{rodauth.csrf_tag(rodauth.unlock_account_request_path)}
   #{rodauth.login_hidden_field}
   #{rodauth.unlock_account_request_explanatory_text}
   <input type="submit" class="btn btn-primary inline" value="#{rodauth.unlock_account_request_button}"/>

--- a/templates/verify-account-resend.str
+++ b/templates/verify-account-resend.str
@@ -1,6 +1,6 @@
-<form action="#{rodauth.prefix}/#{rodauth.verify_account_resend_route}" method="post" class="rodauth form-horizontal" role="form" id="verify-account-resend-form">
+<form action="#{rodauth.verify_account_resend_path}" method="post" class="rodauth form-horizontal" role="form" id="verify-account-resend-form">
   #{rodauth.verify_account_resend_additional_form_tags}
-  #{rodauth.csrf_tag("#{rodauth.prefix}/#{rodauth.verify_account_resend_route}")}
+  #{rodauth.csrf_tag(rodauth.verify_account_resend_path)}
   #{rodauth.verify_account_resend_explanatory_text}
   #{rodauth.param_or_nil(rodauth.login_param) ? rodauth.login_hidden_field : rodauth.render('login-field')}
   #{rodauth.button(rodauth.verify_account_resend_button)}


### PR DESCRIPTION
In #64 we've added `*_path` counterparts to `*_route` methods, and switched most of Rodauth to use them instead of the `*_route` methods. However, we left out templates, so this PR addresses that.
