### PR TITLE
Allow redirecting to originally requested URL after requiring authentication

### DIFF
--- a/doc/login.rdoc
+++ b/doc/login.rdoc
@@ -13,6 +13,8 @@ login_form_footer :: A message to display after the login form.
 login_need_password_notice_flash :: The flash notice to show during multi phase login after the login has been entered, when requesting the password.
 login_notice_flash :: The flash notice to show after successful login.
 login_redirect :: Where to redirect after a sucessful login.
+login_return_to_requested_location? :: Whether to redirect to the originally requested location after successful login when require_login was used, false by default.
+login_redirect_session_key :: The key in the session hash storing the location to redirect to after successful login.
 login_route :: The route to the login action. Defaults to +login+.
 use_multi_phase_login? :: Whether to ask for login first, and only ask for password after asking for the login, false by default.
 

--- a/doc/two_factor_base.rdoc
+++ b/doc/two_factor_base.rdoc
@@ -21,7 +21,9 @@ two_factor_already_authenticated_error_flash :: The flash error to show if going
 two_factor_already_authenticated_redirect :: Where to redirect if going to a two factor authentication page when already authenticated via 2nd factor.
 two_factor_auth_notice_flash :: The flash notice to show after a successful two factor authentication.
 two_factor_auth_redirect :: Where to redirect after a successful two factor authentication.
+two_factor_auth_redirect_session_key :: The key in the session hash storing the location to redirect to after successful two factor authentication.
 two_factor_auth_required_redirect :: Where to redirect if going to a page requiring two factor authentication when not authenticated via 2nd factor (the two factor auth page by default.
+two_factor_auth_return_to_requested_location? :: Whether to redirect to the originally requested location after successful two factor authentication when require_two_factor_authenticated was used, false by default.
 two_factor_disable_additional_form_tags :: HTML fragment containing additional form tags when disabling all two factor authentication.
 two_factor_disable_button :: Text to use for button on form to disable all two factor authentication.
 two_factor_disable_error_flash :: The flash error to show if unable to disable all two factor authentication.

--- a/spec/email_auth_spec.rb
+++ b/spec/email_auth_spec.rb
@@ -205,6 +205,31 @@ describe 'Rodauth email auth feature' do
     page.current_path.must_equal '/'
   end
 
+  it "should allow returning to requested location when login was required" do
+    rodauth do
+      enable :login, :email_auth
+      login_return_to_requested_location? true
+      force_email_auth? true
+    end
+    roda do |r|
+      r.rodauth
+      r.root{view :content=>""}
+      r.get('page') do
+        rodauth.require_login
+        view :content=>""
+      end
+    end
+
+    visit "/page"
+    fill_in 'Login', :with=>'foo@example.com'
+    click_button 'Login'
+    link = email_link(/(\/email-auth\?key=.+)$/)
+
+    visit link
+    click_button 'Login'
+    page.current_path.must_equal "/page"
+  end
+
   it "should clear email auth token when closing account" do
     rodauth do
       enable :login, :email_auth, :close_account

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -1,5 +1,7 @@
 require_relative 'spec_helper'
 
+require 'uri'
+
 describe 'Rodauth login feature' do
   it "should handle logins and logouts" do
     login_column = :f
@@ -124,6 +126,25 @@ describe 'Rodauth login feature' do
     click_button 'Logout'
     page.find('#notice_flash').text.must_equal 'You have been logged out'
     page.current_path.must_equal '/login'
+  end
+
+  it "should allow returning to requested location when login was required" do
+    rodauth do
+      enable :login
+      login_return_to_requested_location? true
+      login_redirect '/'
+    end
+    roda do |r|
+      r.rodauth
+      r.get('page') do
+        rodauth.require_login
+        view :content=>""
+      end
+    end
+
+    visit '/page?foo=bar'
+    login(:visit=>false)
+    URI.parse(page.current_url).request_uri.must_equal '/page?foo=bar'
   end
 
   it "should not allow login to unverified account" do


### PR DESCRIPTION
When the user visits a certain page, but this page requires authentication, it's nice UX if the user is redirected back to the page they originally requested after successful authentication. This pull request adds this feature as discussed on the google group.

We implement this by storing the current location into a session on `login_required` and `require_two_factor_authentication`, and then redirecting back to that location on successful authentication, removing the session value in the process. I chose the "return to" naming as that's what Devise and Clearance use. ~We store the full URL to handle potential subdomains.~

This works with email authentication and webauthn login as well. We use separate settings for login and two factor authentication, as two factor authentication doesn't require the login feature to be loaded, and the user might want to configure these separately anyway (e.g. redirect to two factor auth directly after login, but have two factor authentication remember requested URL).

We don't override `login_redirect` and `two_factor_auth_redirect` so that they can still be used for configuring default redirects for when the user manually visited the authentication page, while still keeping the new functionality.

For login we need to load the session key into an instance variable because `#login_session` clears the session. For that reason I've removed the `#clear_session` call before `POST /login`, which apparently didn't break any tests.

Even though Rodauth 2.0 is on the horizont, I've chosen to disable this feature by default after all, because it could lead to unexpected redirects in scenarios like the following:

1. user browses a website
2. they encounter a page that requires authentication
3. they go back an continue browsing the website some more
4. at some point they decide to manually login in / create account
5. they're redirected to the previously stored URL that was never cleared

This decision also allows us to avoid breaking existing tests that aren't counting with this functionality.

I considered solving this using flash messages that would be discarded when user continues browsing the app (i.e. visits the non-rodauth routes), and thus would reduce the chance for an unexpected redirect. However, it would introduce backwards compatibility for users iterating over all flash keys assuming they're all either message that need displaying. It would also introduce complications with the JWT feature which doesn't load flash by default.
