### PR TITLE
Fix duplicate spec name

### DIFF
--- a/spec/two_factor_spec.rb
+++ b/spec/two_factor_spec.rb
@@ -1448,7 +1448,7 @@ describe 'Rodauth OTP feature' do
     json_request.must_equal [200, [1]]
   end
 
-  it "should allow two factor authentication setup, login, recovery, removal" do
+  it "should call the two factor auth before hook only when setup" do
     before_called = false
     rodauth do
       enable :login, :otp, :logout


### PR DESCRIPTION
I noticed this spec name is the same as the first spec in this file, so I updated the description.
