### PR TITLE
Inline create_account dependencies

### DIFF
--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -2,9 +2,8 @@
 
 module Rodauth
   Feature.define(:create_account, :CreateAccount) do
-    depends :login_password_requirements_base
+    depends :login, :login_password_requirements_base
 
-    depends :login
     notice_flash 'Your account has been created'
     error_flash "There was an error creating your account"
     loaded_templates %w'create-account login-field login-confirm-field password-field password-confirm-field'


### PR DESCRIPTION
This puts `create_account` feature dependencies into the same `depends` call.
