### PR TITLE
Specify the JwtRefresh constant in the Feature.define call

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -1,7 +1,7 @@
 # frozen-string-literal: true
 
 module Rodauth
-  JwtRefresh = Feature.define(:jwt_refresh) do
+  Feature.define(:jwt_refresh, :JwtRefresh) do
     depends :jwt
 
     after 'refresh_token'


### PR DESCRIPTION
This makes jwt_refresh feature definition consistent with all other features.
