### PR TITLE
Remove unused view render in login feature

### DIFF
--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -75,7 +75,6 @@ module Rodauth
       if multi_phase_login_forms.length == 1 && (meth = multi_phase_login_forms[0][2])
         send(meth)
       end
-      multi_phase_login_view
     end
 
     def skip_login_field_on_login?


### PR DESCRIPTION
It noticed a view render that doesn't seem to be used anywhere, so I thought it's probably a leftover from a previous refactor.
