### PR TITLE
Add #require_password_confirmation for easy "sudo" mode

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -966,6 +966,13 @@ require_current_password :: (password_expiration feature) Require a current
                             password, redirecting the request to the change
                             password page if the password for the account has
                             expired.
+require_password_confirmation :: (confirm_password feature) Redirect to the
+                                 password confirmation page, saving the current
+                                 location to redirect back to after password
+                                 has been successfully confirmed. This should
+                                 be wrapped in a conditional that evaluates
+                                 to false after password confirmation to avoid
+                                 endless redirects.
 load_memory :: (remember feature) If the session has not been authenticated, look
                for the remember cookie.  If present and valid, automatically
                log the session in, but mark that it was logged in via a remember

--- a/doc/confirm_password.rdoc
+++ b/doc/confirm_password.rdoc
@@ -18,6 +18,9 @@ confirm_password_notice_flash :: The flash notice to show after password confirm
 confirm_password_redirect :: Where to redirect after successful password confirmation. By default, uses <tt>session[confirm_password_redirect_session_key]</tt> if set, allowing an easy way to redirect back to the page requesting password confirmation.
 confirm_password_redirect_session_key :: The session key used to check for the confirm_password_redirect.
 confirm_password_route :: The route to the confirm password form. Defaults to +confirm-password+.
+need_password_confirmation_error_status :: The response status to use if going to a page requiring password confirmation, 401 by default.
+need_password_confirmation_error_flash :: The flash error to show if going to a page requiring password confirmation.
+password_confirmation_required_redirect :: Where to redirect when going to a page requiring password confirmation.
 
 == Auth Methods
 
@@ -26,3 +29,4 @@ before_confirm_password :: Run arbitrary code before setting that the password h
 confirm_password :: Run arbitrary code on correct password confirmation.
 before_confirm_password_route :: Run arbitrary code before handling the password confirmation route.
 confirm_password_view :: The HTML to use for the confirm password form.
+require_password_confirmation :: Redirect to password confirmation page, saving current location to redirect back to after successful password confirmation.

--- a/doc/password_expiration.rdoc
+++ b/doc/password_expiration.rdoc
@@ -24,7 +24,7 @@ allow_password_change_after :: How long in seconds after the last password chang
 password_expiration_error_flash :: The flash error to display when the account's password has expired and needs to be changed.
 password_not_changeable_yet_error_flash :: The flash error to display when not enough time has elapsed since the last password change and an attempt is made to change the password.
 password_not_changeable_yet_redirect :: Where to redirect if the password cannot be changed yet.
-password_change_needed_redirect :: Where to redirect if a password needs to be changes.
+password_change_needed_redirect :: Where to redirect if a password needs to be changed.
 password_changed_at_session_key :: The key in the session storing the timestamp the password was changed at.
 password_expiration_default :: If the last password change time for an account cannot be determined, whether to consider the account expired, false by default.
 password_expiration_table :: The table holding the password last changed timestamps.

--- a/doc/password_grace_period.rdoc
+++ b/doc/password_grace_period.rdoc
@@ -4,7 +4,19 @@ The password grace period feature keeps track of the last time the
 user entered their password, and doesn't require they reenter their
 password for account modifications if they recently entered it correctly.
 
+If you would like to provide extra security before certain routes, you can use
+the confirm password feature to require users to reenter their password if they
+haven't entered one recently:
+
+  unless rodauth.password_recently_entered?
+    rodauth.require_password_confirmation
+  end
+
 == Auth Value Methods
 
 password_grace_period :: The number of seconds after a password entry until password reentry is required, 300 by default (5 minutes).
 last_password_entry_session_key :: The session key in which to store the last password entry time.
+
+== Auth Methods
+
+password_recently_entered? :: Whether the password has last been entered within the grace period.

--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -4,15 +4,18 @@ module Rodauth
   Feature.define(:confirm_password, :ConfirmPassword) do
     notice_flash "Your password has been confirmed"
     error_flash "There was an error confirming your password"
+    error_flash "You need to confirm your password before continuing", 'need_password_confirmation'
     loaded_templates %w'confirm-password password-field'
     view 'confirm-password', 'Confirm Password'
     additional_form_tags
     button 'Confirm Password'
     before
     after
+    redirect(:password_confirmation_needed){confirm_password_path}
 
     session_key :confirm_password_redirect_session_key, :confirm_password_redirect
     auth_value_method :confirm_password_link_text, "Enter Password"
+    auth_value_method :need_password_confirmation_error_status, 401
 
     auth_value_methods :confirm_password_redirect
 
@@ -43,6 +46,13 @@ module Rodauth
           confirm_password_view
         end
       end
+    end
+
+    def require_password_confirmation
+      set_redirect_error_status(need_password_confirmation_error_status)
+      set_redirect_error_flash need_password_confirmation_error_flash
+      set_session_value(confirm_password_redirect_session_key, request.fullpath)
+      redirect password_confirmation_needed_redirect
     end
 
     def confirm_password

--- a/lib/rodauth/features/password_grace_period.rb
+++ b/lib/rodauth/features/password_grace_period.rb
@@ -5,6 +5,8 @@ module Rodauth
     auth_value_method :password_grace_period, 300
     session_key :last_password_entry_session_key, :last_password_entry
 
+    auth_methods :password_recently_entered?
+
     def modifications_require_password?
       return false unless super
       !password_recently_entered?
@@ -15,6 +17,11 @@ module Rodauth
         @last_password_entry = set_last_password_entry
       end
       v
+    end
+
+    def password_recently_entered?
+      return false unless last_password_entry = session[last_password_entry_session_key]
+      last_password_entry + password_grace_period > Time.now.to_i
     end
 
     private
@@ -32,11 +39,6 @@ module Rodauth
     def update_session
       super
       set_session_value(last_password_entry_session_key, @last_password_entry) if defined?(@last_password_entry)
-    end
-
-    def password_recently_entered?
-      return false unless last_password_entry = session[last_password_entry_session_key]
-      last_password_entry + password_grace_period > Time.now.to_i
     end
 
     def set_last_password_entry


### PR DESCRIPTION
GitHub has a "sudo" mode for sensitive operations, where they redirect to a page where the user can confirm their password before continuing. They also have a grace period, meaning password confirmation is not required if password was entered recently.

The confirm_password feature already provides tools for building this functionality, but it requires a few method calls. So we add a `#require_password_confirmation` method that will redirect to the password confirmation page, then redirect back to the original page. It also respects the password_grace_period feature.
