### PR TITLE
Redisplay the reset password form in validation errors

### DIFF
--- a/doc/reset_password.rdoc
+++ b/doc/reset_password.rdoc
@@ -49,7 +49,6 @@ create_reset_password_key :: Add the reset password key data to the database.
 create_reset_password_email :: A Mail::Message for the reset password email.
 get_reset_password_email_last_sent :: Get the last time a reset password email is sent, or nil if there is no last sent time.
 get_reset_password_key(id) :: Get the password reset key for the given account id from the database.
-login_failed_reset_password_request_form :: The HTML to use for a form to request a password reset, shown on the login page after the user tries to login with an invalid password.
 remove_reset_password_key :: Remove the reset password key for the current account, run after successful password reset.
 reset_password_email_body :: The body to use for the reset password email.
 reset_password_email_link :: The link to the reset password form in the reset password email.

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -68,8 +68,6 @@ module Rodauth
       end
     end
 
-    attr_reader :login_form_header
-
     def after_login_entered_during_multi_phase_login
       set_notice_now_flash need_password_notice_flash
       if multi_phase_login_forms.length == 1 && (meth = multi_phase_login_forms[0][2])

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -45,7 +45,6 @@ module Rodauth
       :create_reset_password_email,
       :get_reset_password_key,
       :get_reset_password_email_last_sent,
-      :login_failed_reset_password_request_form,
       :remove_reset_password_key,
       :reset_password_email_body,
       :reset_password_email_link,
@@ -218,13 +217,6 @@ module Rodauth
 
     attr_reader :reset_password_key_value
 
-    def after_login_failure
-      unless only_json?
-        @login_form_header = login_failed_reset_password_request_form
-      end
-      super
-    end
-
     def after_close_account
       remove_reset_password_key
       super if defined?(super)
@@ -236,10 +228,6 @@ module Rodauth
 
     def create_reset_password_email
       create_email(reset_password_email_subject, reset_password_email_body)
-    end
-
-    def login_failed_reset_password_request_form
-      render("reset-password-request")
     end
 
     def reset_password_email_body

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -66,7 +66,15 @@ module Rodauth
       end
 
       r.post do
-        if account_from_login(param(login_param)) && open_account?
+        catch_error do
+          unless account_from_login(param(login_param))
+            throw_error_status(no_matching_login_error_status, login_param, no_matching_login_message)
+          end
+
+          unless open_account?
+            throw_error_status(unopen_account_error_status, login_param, unverified_account_message)
+          end
+
           if reset_password_email_recently_sent?
             set_redirect_error_flash reset_password_email_recently_sent_error_flash
             redirect reset_password_email_recently_sent_redirect
@@ -81,12 +89,11 @@ module Rodauth
           end
 
           set_notice_flash reset_password_email_sent_notice_flash
-        else
-          set_redirect_error_status(no_matching_login_error_status)
-          set_redirect_error_flash reset_password_request_error_flash
+          redirect reset_password_email_sent_redirect
         end
 
-        redirect reset_password_email_sent_redirect
+        set_error_flash reset_password_request_error_flash
+        reset_password_request_view
       end
     end
 

--- a/spec/password_expiration_spec.rb
+++ b/spec/password_expiration_spec.rb
@@ -13,7 +13,8 @@ describe 'Rodauth password expiration feature' do
       r.root{view :content=>""}
     end
 
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     link = email_link(/(\/reset-password\?key=.+)$/)
 

--- a/spec/password_grace_period_spec.rb
+++ b/spec/password_grace_period_spec.rb
@@ -74,7 +74,8 @@ describe 'Rodauth password grace period feature' do
       r.root{view :content=>rodauth.logged_in? ? "Logged In" : "Not Logged"}
     end
 
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     link = email_link(/(\/reset-password\?key=.+)$/)
     visit link

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -12,45 +12,36 @@ describe 'Rodauth reset_password feature' do
       r.root{view :content=>""}
     end
 
-    login(:login=>'foo@example2.com', :pass=>'01234567')
-    page.html.wont_match(/notice_flash/)
-
-    login(:pass=>'01234567', :visit=>false)
-
-    click_button 'Request Password Reset'
-    page.find('#notice_flash').text.must_equal "An email has been sent to you with a link to reset the password for your account"
-    page.current_path.must_equal '/'
-    link = email_link(/(\/reset-password\?key=.+)$/)
-
-    visit link[0...-1]
-    page.find('#error_flash').text.must_equal "There was an error resetting your password: invalid or expired password reset key"
-
     visit '/login'
     click_link 'Forgot Password?'
+    page.current_path.must_equal '/reset-password-request'
+
     fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
-    email_link(/(\/reset-password\?key=.+)$/).must_equal link
-
-    login(:pass=>'01234567')
-    click_button 'Request Password Reset'
-    email_link(/(\/reset-password\?key=.+)$/).must_equal link
+    link = email_link(/(\/reset-password\?key=.+)$/)
 
     last_sent_column = :email_last_sent
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     page.find('#error_flash').text.must_equal "An email has recently been sent to you with a link to reset your password"
     Mail::TestMailer.deliveries.must_equal []
 
     DB[:account_password_reset_keys].update(:email_last_sent => Time.now - 250).must_equal 1
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     page.find('#error_flash').text.must_equal "An email has recently been sent to you with a link to reset your password"
     Mail::TestMailer.deliveries.must_equal []
 
     DB[:account_password_reset_keys].update(:email_last_sent => Time.now - 350).must_equal 1
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     email_link(/(\/reset-password\?key=.+)$/).must_equal link
+
+    visit link[0...-1]
+    page.find('#error_flash').text.must_equal "There was an error resetting your password: invalid or expired password reset key"
 
     visit link
     page.title.must_equal 'Reset Password'
@@ -105,8 +96,8 @@ describe 'Rodauth reset_password feature' do
       r.root{view :content=>""}
     end
 
-    visit '/login'
-    login(:pass=>'01234567', :visit=>false)
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     page.find('#notice_flash').text.must_equal "An email has been sent to you with a link to reset the password for your account"
 
@@ -127,10 +118,11 @@ describe 'Rodauth reset_password feature' do
       r.root{view :content=>rodauth.logged_in? ? "Logged In" : "Not Logged"}
     end
 
-    login(:pass=>'01234567')
-
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     link = email_link(/(\/reset-password\?key=.+)$/)
+
     visit link
     fill_in 'Password', :with=>'0123456'
     fill_in 'Confirm Password', :with=>'0123456'
@@ -149,7 +141,8 @@ describe 'Rodauth reset_password feature' do
       r.root{view :content=>rodauth.logged_in? ? "Logged In" : "Not Logged"}
     end
 
-    login(:pass=>'01234567')
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     email_link(/(\/reset-password\?key=.+)$/)
 
@@ -172,8 +165,8 @@ describe 'Rodauth reset_password feature' do
       r.root{view :content=>""}
     end
 
-    login(:pass=>'01234567')
-
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     link = email_link(/(\/reset-password\?key=.+)$/)
     visit link

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -16,6 +16,13 @@ describe 'Rodauth reset_password feature' do
     click_link 'Forgot Password?'
     page.current_path.must_equal '/reset-password-request'
 
+    fill_in 'Login', :with=>'foo@example2.com'
+    click_button 'Request Password Reset'
+    page.find('#error_flash').text.must_equal "There was an error requesting a password reset"
+    page.current_path.must_equal '/reset-password-request'
+    page.html.must_include("no matching login")
+    page.all('[type=email]').first.value.must_equal 'foo@example2.com'
+
     fill_in 'Login', :with=>'foo@example.com'
     click_button 'Request Password Reset'
     link = email_link(/(\/reset-password\?key=.+)$/)
@@ -131,6 +138,27 @@ describe 'Rodauth reset_password feature' do
     page.body.must_include("Logged In")
   end
 
+  it "should not allow password reset for unverified account" do
+    rodauth do
+      enable :reset_password
+      skip_status_checks? false
+    end
+    roda do |r|
+      r.rodauth
+      next unless rodauth.logged_in?
+      r.root{view :content=>""}
+    end
+
+    DB[:accounts].update(:status_id=>1)
+
+    visit '/reset-password-request'
+    fill_in 'Login', :with=>'foo@example.com'
+    click_button 'Request Password Reset'
+    page.find('#error_flash').text.must_equal "There was an error requesting a password reset"
+    page.html.must_include("unverified account, please verify account before logging in")
+    page.current_path.must_equal '/reset-password-request'
+  end
+
   it "should clear reset password token when closing account" do
     rodauth do
       enable :login, :reset_password, :close_account
@@ -193,7 +221,7 @@ describe 'Rodauth reset_password feature' do
     res.must_equal [401, {"error"=>"There was an error resetting your password"}]
 
     res = json_request('/reset-password-request', :login=>'foo@example2.com')
-    res.must_equal [401, {"error"=>"There was an error requesting a password reset"}]
+    res.must_equal [401, {"field-error"=>["login", "no matching login"], "error"=>"There was an error requesting a password reset"}]
 
     res = json_request('/reset-password-request', :login=>'foo@example.com')
     res.must_equal [200, {"success"=>"An email has been sent to you with a link to reset the password for your account"}]

--- a/templates/login.str
+++ b/templates/login.str
@@ -1,3 +1,2 @@
-#{rodauth.login_form_header}
 #{rodauth.render('login-form')}
 #{rodauth.login_form_footer}

--- a/templates/multi-phase-login.str
+++ b/templates/multi-phase-login.str
@@ -1,3 +1,2 @@
-#{rodauth.login_form_header}
 #{rodauth.render_multi_phase_login_forms}
 #{rodauth.login_form_footer}

--- a/templates/reset-password-request.str
+++ b/templates/reset-password-request.str
@@ -2,6 +2,6 @@
   #{rodauth.reset_password_request_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.reset_password_request_path)}
   #{rodauth.reset_password_explanatory_text}
-  #{rodauth.param_or_nil(rodauth.login_param) ? rodauth.login_hidden_field : rodauth.render('login-field')}
+  #{rodauth.render('login-field')}
   #{rodauth.button(rodauth.reset_password_request_button)}
 </form>


### PR DESCRIPTION
This redisplays reset password request form in case of validation errors, allowing the user to correct their login if they mistyped it.

In order to do this, I needed to avoid displaying a hidden login field in the form when a login has been entered. I initially thought about just replacing the conditional in the form to use `rodauth.valid_login_entered?` instead, but that is only true when `use_multi_phase_login?` is true as well, so when `use_multi_phase_login?` is false we would be displaying a reset password request form with an email field as well, which is probably not desired.

Since we already have the "Forgot Password?" link always displayed in the login footer, I thought we could get away without display another reset password request button in the login header as well. Yes, the "Forgot Password?" link requires the user the re-type their login, but I think that's a fair trade-off for reduced complexity.

(I initially intended to do this for the email_auth feature as well, but I realized that the email auth request form is currently only displayed as part of a multi-phase login, and doesn't have a `GET` route, so we're good there.)
