### PR TITLE
Make login form footer links more consistent with two factor links

### DIFF
--- a/doc/create_account.rdoc
+++ b/doc/create_account.rdoc
@@ -18,7 +18,7 @@ after_create_account :: Run arbitrary code after creating the account.
 before_create_account :: Run arbitrary code before creating the account.
 before_create_account_route :: Run arbitrary code before handling a create account route.
 create_account_autologin? :: Whether to autologin the user upon successful account creation, true by default unless verifying accounts.
-create_account_link :: HTML fragment to display with a link to the create account form.
+create_account_link_text :: The text to use for a link to the create account form.
 create_account_view :: The HTML to use for the create account form.
 new_account(login) :: Instantiate a new account hash for the given login, without saving it.
 save_account :: Insert the account into the database, or return nil/false if that was not successful.

--- a/doc/reset_password.rdoc
+++ b/doc/reset_password.rdoc
@@ -29,7 +29,7 @@ reset_password_redirect :: Where to redirect after resetting a password.
 reset_password_request_additional_form_tags :: HTML fragment containing additional form tags to use on the reset password request form.
 reset_password_request_button :: The text to use for the reset password request button.
 reset_password_request_error_flash :: The flash error to show if not able to send a reset password email.
-reset_password_request_link :: The HTML to use for a link to the page to request a password reset.
+reset_password_request_link_text :: The text to use for a link to the page to request a password reset.
 reset_password_request_route :: The route to the reset password request action.  Defaults to +reset-password-request+.
 reset_password_route :: The route to the reset password action. Defaults to +reset-password+.
 reset_password_session_key :: The key in the session to hold the reset password key temporarily.

--- a/doc/verify_account.rdoc
+++ b/doc/verify_account.rdoc
@@ -29,7 +29,7 @@ verify_account_resend_button :: The text to use for the verify account resend bu
 verify_account_redirect :: Where to redirect after verifying the account.
 verify_account_resend_error_flash :: The flash error to show if unable to resend a verify account email.
 verify_account_resend_explanatory_text :: The text to display above the button to resend the verify account email.
-verify_account_resend_link :: The HTML to use for a link to the page to request the account verification email be resent.
+verify_account_resend_link_text :: The text to use for a link to the page to request the account verification email be resent.
 verify_account_resend_route :: The route to the verify account resend action.  Defaults to +verify-account-resend+.
 verify_account_route :: The route to the verify account action. Defaults to +verify-account+.
 verify_account_session_key :: The key in the session to hold the verify account key temporarily.

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -15,9 +15,8 @@ module Rodauth
     redirect
 
     auth_value_method :create_account_autologin?, true
+    auth_value_method :create_account_link_text, "Create a New Account"
     auth_value_method :create_account_set_password?, true
-
-    auth_value_methods :create_account_link
 
     auth_methods(
       :save_account,
@@ -87,10 +86,6 @@ module Rodauth
       end
     end
 
-    def create_account_link
-      "<a href=\"#{create_account_path}\">Create a New Account</a>"
-    end
-
     def set_new_account_password(password)
       account[account_password_hash_column] = password_hash(password)
     end
@@ -117,7 +112,7 @@ module Rodauth
     private
 
     def _login_form_footer_links
-      super << [10, create_account_link]
+      super << [10, create_account_path, create_account_link_text]
     end
 
     def _new_account(login)

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -5,7 +5,7 @@ module Rodauth
     notice_flash "You have been logged in"
     notice_flash "Login recognized, please enter your password", "need_password"
     error_flash "There was an error logging in"
-    loaded_templates %w'login login-form multi-phase-login login-field password-field login-display'
+    loaded_templates %w'login login-form login-form-footer multi-phase-login login-field password-field login-display'
     view 'login', 'Login'
     view 'multi-phase-login', 'Login', 'multi_phase_login'
     additional_form_tags
@@ -112,18 +112,7 @@ module Rodauth
     end
 
     def _login_form_footer
-      links = _login_form_footer_links
-      return '' if links.empty?
-
-      footer = String.new
-      footer << '<div class="col-sm-offset-2 col-sm-10">'
-      footer << login_form_footer_links_heading
-      footer << '<ul class="rodauth-links rodauth-login-footer-links">'
-      links.sort.each do |_, link|
-        footer << "<li>#{link}</li>\n"
-      end
-      footer << "</ul></div>"
-      footer
+      render('login-form-footer')
     end
 
     def _login(auth_type)

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -36,9 +36,8 @@ module Rodauth
     auth_value_method :reset_password_email_last_sent_column, nil
     auth_value_method :reset_password_explanatory_text, "<p>If you have forgotten your password, you can request a password reset:</p>"
     auth_value_method :reset_password_skip_resend_email_within, 300
+    auth_value_method :reset_password_request_link_text, "Forgot Password?"
     session_key :reset_password_session_key, :reset_password_key
-
-    auth_value_methods :reset_password_request_link
 
     auth_methods(
       :create_reset_password_key,
@@ -190,10 +189,6 @@ module Rodauth
       ds.get(reset_password_key_column)
     end
 
-    def reset_password_request_link
-      "<a href=\"#{reset_password_request_path}\">Forgot Password?</a>"
-    end
-
     def set_reset_password_email_last_sent
        password_reset_ds.update(reset_password_email_last_sent_column=>Sequel::CURRENT_TIMESTAMP) if reset_password_email_last_sent_column
     end
@@ -209,7 +204,7 @@ module Rodauth
     private
 
     def _login_form_footer_links
-      super << [20, reset_password_request_link]
+      super << [20, reset_password_request_path, reset_password_request_link_text]
     end
 
     def reset_password_email_recently_sent?

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -36,6 +36,7 @@ module Rodauth
     auth_value_method :verify_account_skip_resend_email_within, 300
     auth_value_method :verify_account_key_column, :key
     auth_value_method :verify_account_resend_explanatory_text, "<p>If you no longer have the email to verify the account, you can request that it be resent to you:</p>"
+    auth_value_method :verify_account_resend_link_text, "Resend Verify Account Information"
     session_key :verify_account_session_key, :verify_account_key
     auth_value_method :verify_account_set_password?, true
 
@@ -220,10 +221,6 @@ module Rodauth
       false
     end
 
-    def verify_account_resend_link
-      "<a href=\"#{verify_account_resend_path}\">Resend Verify Account Information</a>"
-    end
-
     def create_account_set_password?
       return false if verify_account_set_password?
       super
@@ -246,7 +243,7 @@ module Rodauth
     def _login_form_footer_links
       links = super
       if !param_or_nil(login_param) || ((account || account_from_login(param(login_param))) && allow_resending_verify_account_email?)
-        links << [30, verify_account_resend_link]
+        links << [30, verify_account_resend_path, verify_account_resend_link_text]
       end
       links
     end

--- a/templates/login-form-footer.str
+++ b/templates/login-form-footer.str
@@ -1,0 +1,8 @@
+<div class="col-sm-offset-2 col-sm-10">
+  #{rodauth.login_form_footer_links_heading}
+  <ul class="rodauth-links rodauth-login-footer-links">
+  #{rodauth.login_form_footer_links.sort.map do |_, link, text|
+    "<li><a href=\"#{h link}\">#{h text}</a></li>"
+  end.join("\n")}
+  </ul>
+</div>

--- a/templates/login.str
+++ b/templates/login.str
@@ -1,3 +1,3 @@
 #{rodauth.login_form_header}
 #{rodauth.render('login-form')}
-#{rodauth.login_form_footer}
+#{rodauth.login_form_footer unless rodauth.login_form_footer_links.empty?}

--- a/templates/multi-phase-login.str
+++ b/templates/multi-phase-login.str
@@ -1,3 +1,3 @@
 #{rodauth.login_form_header}
 #{rodauth.render_multi_phase_login_forms}
-#{rodauth.login_form_footer}
+#{rodauth.login_form_footer unless rodauth.login_form_footer_links.empty?}


### PR DESCRIPTION
I noticed that login form footer links are implemented slightly differently than the two factor links, in a way that the whole link is stored instead of just link text. If this was done intentionally for backwards compatibility with existing `*_link` methods, please disregard this pull request.

In this pull request I extracted only link texts into value methods, which makes it easier for someone to write a custom template (as they can still read the link texts array but customize the link markup). I've also moved the login form footer into a template to simplify markup generation.
