### PR TITLE
Remove confirm_password dependency for remember feature

### DIFF
--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -1,10 +1,12 @@
 = Documentation for Remember Feature
 
-The remember feature allows for token-based autologin for users. It records
-which sessions were autologged in via a token, and allows you to request
-password confirmation later for such sessions if they are accessing a
-section requiring more security.  The remember feature depends on the
-logout feature.
+The remember feature allows for token-based autologin for users. Calling
+`rodauth.remember_login` for an authenticated session will create a token for
+the current account and store it in a cookie. You can then add the following
+code to your routing block to automatically login users from that token if the
+session has expired:
+
+  rodauth.load_memory
 
 By default, the remember feature just supports a form that the user can use
 to change their remember settings for the current browser.  They can either
@@ -17,6 +19,15 @@ remembering on login, you can do that via:
 
   after_login do
     remember_login
+  end
+
+The remember feature records which sessions were autologged in via a token. If
+you have sections where you want to add more security, you can use the confirm
+password feature to request password confirmation for sessions autologged in
+via a remember token:
+
+  if rodauth.logged_in_via_remember_key?
+    rodauth.require_password_confirmation
   end
 
 == Auth Value Methods

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -2,8 +2,6 @@
 
 module Rodauth
   Feature.define(:remember, :Remember) do
-    depends :confirm_password
-
     notice_flash "Your remember setting has been updated"
     error_flash "There was an error updating your remember setting"
     loaded_templates %w'remember'

--- a/spec/remember_spec.rb
+++ b/spec/remember_spec.rb
@@ -190,7 +190,7 @@ describe 'Rodauth remember feature' do
 
   it "should support clearing remembered flag" do
     rodauth do
-      enable :login, :remember
+      enable :login, :confirm_password, :remember
     end
     roda do |r|
       r.rodauth
@@ -378,7 +378,7 @@ describe 'Rodauth remember feature' do
 
   it "should support login via remember token via jwt" do
     rodauth do
-      enable :login, :remember
+      enable :login, :confirm_password, :remember
     end
     roda(:jwt) do |r|
       r.rodauth


### PR DESCRIPTION
The confirm_password feature was originally part of the remember feature, but now that it's extracted, it appears to me these two features are in fact decoupled from one another. If I'm mistaken, please disregard this pull request.

While it provides extra security to require password confirmation for sensitive parts of the app when logged in via remember token, for those that aren't doing this it's beneficial if they don't need to load the confirm_password feature code.
