### PR TITLE
Remove remembered session key

### DIFF
--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -44,7 +44,6 @@ remember_remember_label :: The label for turning on remembering.
 remember_route :: The route to the change remember settings action. Defaults to +remember+.
 remember_table :: The name of the remember keys table.
 remember_param :: The parameter name to use for the remember password settings choice.
-remembered_session_key :: The key in the session storing whether the current session has been autologged in via remember token.
 
 == Auth Methods
 

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -20,7 +20,6 @@ module Rodauth
     auth_value_method :remember_cookie_options, {}
     auth_value_method :extend_remember_deadline?, false
     auth_value_method :remember_period, {:days=>14}
-    session_key :remembered_session_key, :remembered
     auth_value_method :remember_deadline_interval, {:days=>14}
     auth_value_method :remember_id_column, :id
     auth_value_method :remember_key_column, :key
@@ -121,7 +120,6 @@ module Rodauth
       before_load_memory
       login_session('remember')
 
-      set_session_value(remembered_session_key, true)
       if extend_remember_deadline?
         active_remember_key_ds(id).update(remember_deadline_column=>Sequel.date_add(Sequel::CURRENT_TIMESTAMP, remember_period))
         remember_login

--- a/spec/remember_spec.rb
+++ b/spec/remember_spec.rb
@@ -114,7 +114,7 @@ describe 'Rodauth remember feature' do
         rodauth.load_memory
         r.redirect '/'
       end
-      r.root{rodauth.logged_in? ? "Logged In#{session[:remembered]}" : "Not Logged In"}
+      r.root{rodauth.logged_in? ? "Logged In" : "Not Logged In"}
     end
 
     login
@@ -250,7 +250,17 @@ describe 'Rodauth remember feature' do
         rodauth.load_memory
         r.redirect '/'
       end
-      r.root{rodauth.logged_in? ? "Logged In#{session[rodauth.remembered_session_key]}" : "Not Logged In"}
+      r.root do
+        if rodauth.logged_in?
+          if rodauth.logged_in_via_remember_key?
+            "Logged In via Remember"
+          else
+            "Logged In Normally"
+          end
+        else
+          "Not Logged In"
+        end
+      end
     end
 
     login
@@ -268,7 +278,7 @@ describe 'Rodauth remember feature' do
 
     old_expiration = page.driver.browser.rack_mock_session.cookie_jar.instance_variable_get(:@cookies).first.expires
     visit '/load'
-    page.body.must_equal 'Logged Intrue'
+    page.body.must_equal 'Logged In via Remember'
     new_expiration = page.driver.browser.rack_mock_session.cookie_jar.instance_variable_get(:@cookies).first.expires
     new_expiration.must_be :>=, old_expiration
     deadline = DB[:account_remember_keys].get(:deadline)
@@ -283,7 +293,7 @@ describe 'Rodauth remember feature' do
     roda do |r|
       r.rodauth
       rodauth.load_memory
-      r.root{rodauth.logged_in? ? "Logged In#{session[:remembered]}" : "Not Logged In"}
+      r.root{rodauth.logged_in? ? "Logged In" : "Not Logged In"}
     end
 
     login


### PR DESCRIPTION
Now that we're storing the authentication method in the `authenticated_by` session key, which we are using to check whether the current session has been autologged in via a remember token, I believe we don't need the `remembered` session key anymore.