### PR TITLE
Fix checking #login_uses_email? for autocomplete

### DIFF
--- a/templates/login-confirm-field.str
+++ b/templates/login-confirm-field.str
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="col-sm-2 control-label" for="login-confirm">#{rodauth.login_confirm_label}#{rodauth.input_field_label_suffix}</label>
   <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.login_confirm_param, 'login-confirm', :type=>rodauth.login_input_type, :autocomplete=>:login_uses_email? ? "email" : "on")}
+    #{rodauth.input_field_string(rodauth.login_confirm_param, 'login-confirm', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
   </div>
 </div>

--- a/templates/login-field.str
+++ b/templates/login-field.str
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="col-sm-2 control-label" for="login">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
   <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>:login_uses_email? ? "email" : "on")}
+    #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
   </div>
 </div>


### PR DESCRIPTION
Fixes the condition for the login autocomplete value to call the `#login_uses_email?` method.
