### PR TITLE
Specify webauthn auth form action directly

### DIFF
--- a/doc/webauthn.rdoc
+++ b/doc/webauthn.rdoc
@@ -25,7 +25,6 @@ webauthn_auth_button :: Text to use for button on form to authenticate via WebAu
 webauthn_auth_challenge_hmac_param :: The parameter name for the HMAC of the WebAuthn challenge during authentication.
 webauthn_auth_challenge_param :: The parameter name for the WebAuthn challenge during authentication.
 webauthn_auth_error_flash :: The flash error to show if unable to authenticate via WebAuthn.
-webauthn_auth_form_attr :: Attributes to add to the webauthn auth form.
 webauthn_auth_js :: The javascript code to execute on the page to authenticate via WebAuthn.
 webauthn_auth_link_text :: The text to use for the link from the two factor auth page.
 webauthn_auth_param :: The parameter name for the WebAuthn authentication data.

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -74,7 +74,6 @@ module Rodauth
     auth_value_method :webauthn_attestation, 'none'
 
     auth_value_method :webauthn_not_setup_error_status, 403
-    auth_value_method :webauthn_auth_form_attr, ''
 
     translatable_method :webauthn_invalid_setup_param_message, "invalid webauthn setup param"
     translatable_method :webauthn_duplicate_webauthn_id_message, "attempt to insert duplicate webauthn id"

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -32,14 +32,6 @@ module Rodauth
       end
     end
 
-    def webauthn_auth_form_attr
-      if @webauthn_login
-        "action=\"#{webauthn_login_path}\""
-      else
-        super
-      end
-    end
-
     def webauthn_auth_additional_form_tags
       if @webauthn_login
         super.to_s + login_hidden_field

--- a/templates/webauthn-auth.str
+++ b/templates/webauthn-auth.str
@@ -1,4 +1,4 @@
-<form method="post" #{rodauth.webauthn_auth_form_attr} class="rodauth form-horizontal" role="form" id="rodauth-webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauth_credential_options_for_get).as_json.to_json)}">
+<form method="post" action="#{rodauth.webauthn_auth_form_path}" class="rodauth form-horizontal" role="form" id="rodauth-webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauth_credential_options_for_get).as_json.to_json)}">
   #{rodauth.webauthn_auth_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.webauthn_auth_form_path)}
   <input type="hidden" name="#{rodauth.webauthn_auth_challenge_param}" value="#{cred.challenge}" />


### PR DESCRIPTION
In rodauth-rails, I'm rewriting Rodauth templates into Rails ERB views, and I found everything directly translatable, with the exception of the `webauthn_auth_form_attr` usage in the `webauthn-auth` template. This is because in Rails it's a given to use `form_*` helper method, which cannot really utilize a raw HTML attribute list without parsing.

I've noticed that the `webauthn_auth_form_attr` setting seems to only be used currently by the webauthn_login feature to set the form action. And since webauthn_login also overrides `webauthn_auth_form_path` with the same value, I thought we could just use that directly. I don't know if there were plans to utilize `webauthn_auth_form_attr` further than that.

This changes the form `action` value of a regular webauthn auth form without webauthn_login feature loaded to be explicitly set. I don't know if that changes behaviour.
