### PR TITLE
Make templates compatible with Bootstrap 4

### DIFF
--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -89,9 +89,7 @@ module Rodauth
     end
 
     def logout_additional_form_tags
-      input = input_field_string(global_logout_param, "rodauth-global-logout", :type=>'checkbox', :skip_error_message=>true, :value=>'t', :required=>false)
-      input = "<label class=\"rodauth-global-logout-label\">#{input} #{global_logout_label}</label>"
-      super.to_s + input
+      super.to_s + render('global-logout-field')
     end
 
     def update_session

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -25,8 +25,8 @@ module Rodauth
     session_key :flash_notice_key, :notice
     auth_value_method :hmac_secret, nil
     translatable_method :input_field_label_suffix, ''
-    auth_value_method :input_field_error_class, 'error'
-    auth_value_method :input_field_error_message_class, 'error_message'
+    auth_value_method :input_field_error_class, 'error is-invalid'
+    auth_value_method :input_field_error_message_class, 'error_message invalid-feedback'
     auth_value_method :invalid_field_error_status, 422
     auth_value_method :invalid_key_error_status, 401
     auth_value_method :invalid_password_error_status, 401

--- a/templates/button.str
+++ b/templates/button.str
@@ -1,5 +1,3 @@
 <div class="form-group">
-  <div class="col-sm-offset-2 col-sm-10">
-    <input type="submit" #{"name=\"#{h opts[:name]}\"" if opts[:name]} class="#{h(opts[:class] || 'btn btn-primary')}" value="#{h value}"/>
-  </div>
+  <input type="submit" #{"name=\"#{h opts[:name]}\"" if opts[:name]} class="#{h(opts[:class] || 'btn btn-primary')}" value="#{h value}"/>
 </div>

--- a/templates/change-login.str
+++ b/templates/change-login.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="change-login-form">
+<form method="post" class="rodauth" role="form" id="change-login-form">
   #{rodauth.change_login_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('login-field')}

--- a/templates/change-password.str
+++ b/templates/change-password.str
@@ -1,12 +1,10 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="change-password-form">
+<form method="post" class="rodauth" role="form" id="change-password-form">
   #{rodauth.change_password_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.change_password_requires_password?}
   <div class="form-group">
-    <label class="col-sm-2 control-label" for="new-password">#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}</label>
-    <div class="col-sm-10">
-      #{rodauth.input_field_string(rodauth.new_password_param, 'new-password', :type => 'password', :autocomplete=>"new-password")}
-    </div>
+    <label for="new-password">#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}</label>
+    #{rodauth.input_field_string(rodauth.new_password_param, 'new-password', :type => 'password', :autocomplete=>"new-password")}
   </div>
   #{rodauth.render('password-confirm-field') if rodauth.require_password_confirmation?}
   #{rodauth.button(rodauth.change_password_button)}

--- a/templates/close-account.str
+++ b/templates/close-account.str
@@ -1,6 +1,6 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="close-account-form">
+<form method="post" class="rodauth" role="form" id="close-account-form">
   #{rodauth.close_account_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.close_account_requires_password?}
-  #{rodauth.button(rodauth.close_account_button, :class=>'btn btn-warning')}
+  #{rodauth.button(rodauth.close_account_button, :class=>'btn btn-danger')}
 </form>

--- a/templates/confirm-password.str
+++ b/templates/confirm-password.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="confirm-password-form">
+<form method="post" class="rodauth" role="form" id="confirm-password-form">
   #{rodauth.confirm_password_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field')}

--- a/templates/create-account.str
+++ b/templates/create-account.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="create-account-form">
+<form method="post" class="rodauth" role="form" id="create-account-form">
   #{rodauth.create_account_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('login-field')}

--- a/templates/email-auth-request-form.str
+++ b/templates/email-auth-request-form.str
@@ -1,4 +1,4 @@
-<form action="#{rodauth.email_auth_request_path}" method="post" class="rodauth form-horizontal" role="form" id="email-auth-request-form">
+<form action="#{rodauth.email_auth_request_path}" method="post" class="rodauth" role="form" id="email-auth-request-form">
   #{rodauth.email_auth_request_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.email_auth_request_path)}
   #{rodauth.login_hidden_field}

--- a/templates/email-auth.str
+++ b/templates/email-auth.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="email-auth-form">
+<form method="post" class="rodauth" role="form" id="email-auth-form">
   #{rodauth.email_auth_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.button(rodauth.login_button)}

--- a/templates/global-logout-field.str
+++ b/templates/global-logout-field.str
@@ -1,0 +1,6 @@
+<div class="form-group">
+  <div class="form-check checkbox">
+    <input type="checkbox" name="#{rodauth.global_logout_param}" class="form-check-input" id="rodauth-global-logout" value="t"/>
+    <label class="rodauth-global-logout-label form-check-label" for="rodauth-global-logout">#{rodauth.global_logout_label}</label>
+  </div>
+</div>

--- a/templates/login-confirm-field.str
+++ b/templates/login-confirm-field.str
@@ -1,6 +1,4 @@
 <div class="form-group">
-  <label class="col-sm-2 control-label" for="login-confirm">#{rodauth.login_confirm_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.login_confirm_param, 'login-confirm', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
-  </div>
+  <label for="login-confirm">#{rodauth.login_confirm_label}#{rodauth.input_field_label_suffix}</label>
+  #{rodauth.input_field_string(rodauth.login_confirm_param, 'login-confirm', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
 </div>

--- a/templates/login-display.str
+++ b/templates/login-display.str
@@ -1,4 +1,4 @@
 <div class="form-group">
-  <label class="col-sm-2 control-label">#{rodauth.login_label}</label>
-  <div class="col-sm-10">#{rodauth.login_hidden_field}#{h rodauth.param(rodauth.login_param)}</div>
+  <label for="login">#{rodauth.login_label}</label>
+  #{rodauth.login_hidden_field}<div class="form-control-plaintext form-control-static">#{h rodauth.param(rodauth.login_param)}</div>
 </div>

--- a/templates/login-field.str
+++ b/templates/login-field.str
@@ -1,6 +1,4 @@
 <div class="form-group">
-  <label class="col-sm-2 control-label" for="login">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
-  </div>
+  <label for="login">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
+  #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
 </div>

--- a/templates/login-form-footer.str
+++ b/templates/login-form-footer.str
@@ -1,8 +1,6 @@
-<div class="col-sm-offset-2 col-sm-10">
-  #{rodauth.login_form_footer_links_heading}
-  <ul class="rodauth-links rodauth-login-footer-links">
-  #{rodauth.login_form_footer_links.sort.map do |_, link, text|
-    "<li><a href=\"#{h link}\">#{h text}</a></li>"
-  end.join("\n")}
-  </ul>
-</div>
+#{rodauth.login_form_footer_links_heading}
+<ul class="rodauth-links rodauth-login-footer-links">
+#{rodauth.login_form_footer_links.sort.map do |_, link, text|
+  "<li><a href=\"#{h link}\">#{h text}</a></li>"
+end.join("\n")}
+</ul>

--- a/templates/login-form.str
+++ b/templates/login-form.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="login-form">
+<form method="post" class="rodauth" role="form" id="login-form">
   #{rodauth.login_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.skip_login_field_on_login? ? rodauth.render('login-display') : rodauth.render('login-field')}

--- a/templates/logout.str
+++ b/templates/logout.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="logout-form">
+<form method="post" class="rodauth" role="form" id="logout-form">
   #{rodauth.logout_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.button(rodauth.logout_button, :class=>'btn btn-warning')}

--- a/templates/otp-auth-code-field.str
+++ b/templates/otp-auth-code-field.str
@@ -1,6 +1,8 @@
 <div class="form-group">
-  <label class="col-sm-4 control-label" for="otp-auth-code">#{rodauth.otp_auth_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-3">
-    #{rodauth.input_field_string(rodauth.otp_auth_param, 'otp-auth-code', :value=>'', :autocomplete=>"off", :inputmode=>'numeric')}
+  <label for="otp-auth-code">#{rodauth.otp_auth_label}#{rodauth.input_field_label_suffix}</label>
+  <div class="row">
+    <div class="col-sm-3">
+      #{rodauth.input_field_string(rodauth.otp_auth_param, 'otp-auth-code', :value=>'', :autocomplete=>"off", :inputmode=>'numeric')}
+    </div>
   </div>
 </div>

--- a/templates/otp-auth.str
+++ b/templates/otp-auth.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="otp-auth-form">
+<form method="post" class="rodauth" role="form" id="otp-auth-form">
   #{rodauth.otp_auth_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('otp-auth-code-field')}

--- a/templates/otp-disable.str
+++ b/templates/otp-disable.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="otp-disable-form">
+<form method="post" class="rodauth" role="form" id="otp-disable-form">
   #{rodauth.otp_disable_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}

--- a/templates/otp-setup.str
+++ b/templates/otp-setup.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="otp-setup-form">
+<form method="post" class="rodauth" role="form" id="otp-setup-form">
   #{rodauth.otp_setup_additional_form_tags}
   <input type="hidden" id="otp-key" name="#{rodauth.otp_setup_param}" value="#{rodauth.otp_user_key}" />
   #{"<input type=\"hidden\" id=\"otp-hmac-secret\" name=\"#{rodauth.otp_setup_raw_param}\" value=\"#{rodauth.otp_key}\" />" if rodauth.otp_keys_use_hmac?}

--- a/templates/password-confirm-field.str
+++ b/templates/password-confirm-field.str
@@ -1,6 +1,4 @@
 <div class="form-group">
-  <label class="col-sm-2 control-label" for="password-confirm">#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.password_confirm_param, 'password-confirm', :type => 'password', :autocomplete=>'new-password')}
-  </div>
+  <label for="password-confirm">#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}</label>
+  #{rodauth.input_field_string(rodauth.password_confirm_param, 'password-confirm', :type => 'password', :autocomplete=>'new-password')}
 </div>

--- a/templates/password-field.str
+++ b/templates/password-field.str
@@ -1,6 +1,4 @@
 <div class="form-group">
-  <label class="col-sm-2 control-label" for="password">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-10">
-    #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>'current-password')}
-  </div>
+  <label for="password">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
+  #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>'current-password')}
 </div>

--- a/templates/recovery-auth.str
+++ b/templates/recovery-auth.str
@@ -1,11 +1,9 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="recovery-auth-form">
+<form method="post" class="rodauth" role="form" id="recovery-auth-form">
   #{rodauth.recovery_auth_additional_form_tags}
   #{rodauth.csrf_tag}
   <div class="form-group">
-    <label class="col-sm-2 control-label" for="recovery_code">#{rodauth.recovery_codes_label}#{rodauth.input_field_label_suffix}</label>
-    <div class="col-sm-10">
-      #{rodauth.input_field_string(rodauth.recovery_codes_param, 'recovery_code', :value => '', :autocomplete=>'off')}
-    </div>
+    <label for="recovery_code">#{rodauth.recovery_codes_label}#{rodauth.input_field_label_suffix}</label>
+    #{rodauth.input_field_string(rodauth.recovery_codes_param, 'recovery_code', :value => '', :autocomplete=>'off')}
   </div>
   #{rodauth.button(rodauth.recovery_auth_button)}
 </form>

--- a/templates/recovery-codes.str
+++ b/templates/recovery-codes.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="recovery-codes-form">
+<form method="post" class="rodauth" role="form" id="recovery-codes-form">
   #{rodauth.recovery_codes_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}

--- a/templates/remember.str
+++ b/templates/remember.str
@@ -1,23 +1,19 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="remember-form">
+<form method="post" class="rodauth" role="form" id="remember-form">
   #{rodauth.remember_additional_form_tags}
   #{rodauth.csrf_tag}
-  <div class="radio">
-    <label>
-      <input type="radio" name="#{rodauth.remember_param}" id="remember_remember" value="#{rodauth.remember_remember_param_value}"/>
-      #{rodauth.remember_remember_label}
-    </label>
-  </div>
-  <div class="radio">
-    <label>
-      <input type="radio" name="#{rodauth.remember_param}" id="remember_forget" value="#{rodauth.remember_forget_param_value}"/>
-      #{rodauth.remember_forget_label}
-    </label>
-  </div>
-  <div class="radio">
-    <label>
-      <input type="radio" name="#{rodauth.remember_param}" id="remember_disable" value="#{rodauth.remember_disable_param_value}"/>
-      #{rodauth.remember_disable_label}
-    </label>
-  </div>
+  <fieldset class="form-group">
+    <div class="form-check radio">
+      <input type="radio" name="#{rodauth.remember_param}" id="remember_remember" value="#{rodauth.remember_remember_param_value}" class="form-check-input"/>
+      <label class="form-check-label" for="remember_remember">#{rodauth.remember_remember_label}</label>
+    </div>
+    <div class="form-check radio">
+      <input type="radio" name="#{rodauth.remember_param}" id="remember_forget" value="#{rodauth.remember_forget_param_value}" class="form-check-input"/>
+      <label class="form-check-label" for="remember_forget">#{rodauth.remember_forget_label}</label>
+    </div>
+    <div class="form-check radio">
+      <input type="radio" name="#{rodauth.remember_param}" id="remember_disable" value="#{rodauth.remember_disable_param_value}" class="form-check-input"/>
+      <label class="form-check-label" for="remember_disable">#{rodauth.remember_disable_label}</label>
+    </div>
+  </fieldset>
   #{rodauth.button(rodauth.remember_button)}
 </form>

--- a/templates/reset-password-request.str
+++ b/templates/reset-password-request.str
@@ -1,4 +1,4 @@
-<form action="#{rodauth.reset_password_request_path}" method="post" class="rodauth form-horizontal" role="form" id="reset-password-request-form">
+<form action="#{rodauth.reset_password_request_path}" method="post" class="rodauth" role="form" id="reset-password-request-form">
   #{rodauth.reset_password_request_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.reset_password_request_path)}
   #{rodauth.reset_password_explanatory_text}

--- a/templates/reset-password.str
+++ b/templates/reset-password.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="reset-password-form">
+<form method="post" class="rodauth" role="form" id="reset-password-form">
   #{rodauth.reset_password_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field')}

--- a/templates/sms-auth.str
+++ b/templates/sms-auth.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="sms-auth-form">
+<form method="post" class="rodauth" role="form" id="sms-auth-form">
   #{rodauth.sms_auth_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('sms-code-field')}

--- a/templates/sms-code-field.str
+++ b/templates/sms-code-field.str
@@ -1,6 +1,8 @@
 <div class="form-group">
-  <label class="col-sm-3 control-label" for="sms-code">#{rodauth.sms_code_label}#{rodauth.input_field_label_suffix}</label>
-  <div class="col-sm-3">
-    #{rodauth.input_field_string(rodauth.sms_code_param, 'sms-code', :value => '', :autocomplete=>'one-time-code', :inputmode=>'numeric')}
+  <label for="sms-code">#{rodauth.sms_code_label}#{rodauth.input_field_label_suffix}</label>
+  <div class="row">
+    <div class="col-sm-3">
+      #{rodauth.input_field_string(rodauth.sms_code_param, 'sms-code', :value => '', :autocomplete=>'one-time-code', :inputmode=>'numeric')}
+    </div>
   </div>
 </div>

--- a/templates/sms-confirm.str
+++ b/templates/sms-confirm.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="sms-confirm-form">
+<form method="post" class="rodauth" role="form" id="sms-confirm-form">
   #{rodauth.sms_confirm_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('sms-code-field')}

--- a/templates/sms-disable.str
+++ b/templates/sms-disable.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="sms-disable-form">
+<form method="post" class="rodauth" role="form" id="sms-disable-form">
   #{rodauth.sms_disable_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}

--- a/templates/sms-request.str
+++ b/templates/sms-request.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="sms-request-form">
+<form method="post" class="rodauth" role="form" id="sms-request-form">
   #{rodauth.sms_request_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.button(rodauth.sms_request_button)}

--- a/templates/sms-setup.str
+++ b/templates/sms-setup.str
@@ -1,11 +1,13 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="sms-setup-form">
+<form method="post" class="rodauth" role="form" id="sms-setup-form">
   #{rodauth.sms_setup_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
   <div class="form-group">
-    <label class="col-sm-2 control-label" for="sms-phone">#{rodauth.sms_phone_label}#{rodauth.input_field_label_suffix}</label>
-    <div class="col-sm-3">
-      #{rodauth.input_field_string(rodauth.sms_phone_param, 'sms-phone', :type=>rodauth.sms_phone_input_type, :autocomplete=>'tel')}
+    <label for="sms-phone">#{rodauth.sms_phone_label}#{rodauth.input_field_label_suffix}</label>
+    <div class="row">
+      <div class="col-sm-3">
+        #{rodauth.input_field_string(rodauth.sms_phone_param, 'sms-phone', :type=>rodauth.sms_phone_input_type, :autocomplete=>'tel')}
+      </div>
     </div>
   </div>
   #{rodauth.button(rodauth.sms_setup_button)}

--- a/templates/two-factor-disable.str
+++ b/templates/two-factor-disable.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="rodauth-two-factor-disable-form">
+<form method="post" class="rodauth" role="form" id="rodauth-two-factor-disable-form">
   #{rodauth.two_factor_disable_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}

--- a/templates/unlock-account-request.str
+++ b/templates/unlock-account-request.str
@@ -1,7 +1,7 @@
-<form action="#{rodauth.unlock_account_request_path}" method="post" class="rodauth form-horizontal" role="form" id="unlock-account-request-form">
+<form action="#{rodauth.unlock_account_request_path}" method="post" class="rodauth" role="form" id="unlock-account-request-form">
   #{rodauth.unlock_account_request_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.unlock_account_request_path)}
   #{rodauth.login_hidden_field}
   #{rodauth.unlock_account_request_explanatory_text}
-  <input type="submit" class="btn btn-primary inline" value="#{rodauth.unlock_account_request_button}"/>
+  #{rodauth.button(rodauth.unlock_account_request_button)}
 </form>

--- a/templates/unlock-account.str
+++ b/templates/unlock-account.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="unlock-account-form">
+<form method="post" class="rodauth" role="form" id="unlock-account-form">
   #{rodauth.unlock_account_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.unlock_account_explanatory_text}

--- a/templates/verify-account-resend.str
+++ b/templates/verify-account-resend.str
@@ -1,4 +1,4 @@
-<form action="#{rodauth.verify_account_resend_path}" method="post" class="rodauth form-horizontal" role="form" id="verify-account-resend-form">
+<form action="#{rodauth.verify_account_resend_path}" method="post" class="rodauth" role="form" id="verify-account-resend-form">
   #{rodauth.verify_account_resend_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.verify_account_resend_path)}
   #{rodauth.verify_account_resend_explanatory_text}

--- a/templates/verify-account.str
+++ b/templates/verify-account.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="verify-account-form">
+<form method="post" class="rodauth" role="form" id="verify-account-form">
   #{rodauth.verify_account_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.verify_account_set_password?}

--- a/templates/verify-login-change.str
+++ b/templates/verify-login-change.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="verify-login-change-form">
+<form method="post" class="rodauth" role="form" id="verify-login-change-form">
   #{rodauth.verify_login_change_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.button(rodauth.verify_login_change_button)}

--- a/templates/webauthn-auth.str
+++ b/templates/webauthn-auth.str
@@ -1,4 +1,4 @@
-<form method="post" action="#{rodauth.webauthn_auth_form_path}" class="rodauth form-horizontal" role="form" id="rodauth-webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauth_credential_options_for_get).as_json.to_json)}">
+<form method="post" action="#{rodauth.webauthn_auth_form_path}" class="rodauth" role="form" id="rodauth-webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauth_credential_options_for_get).as_json.to_json)}">
   #{rodauth.webauthn_auth_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.webauthn_auth_form_path)}
   <input type="hidden" name="#{rodauth.webauthn_auth_challenge_param}" value="#{cred.challenge}" />

--- a/templates/webauthn-remove.str
+++ b/templates/webauthn-remove.str
@@ -1,11 +1,11 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="rodauth-webauthn-remove-form">
+<form method="post" class="rodauth" role="form" id="rodauth-webauthn-remove-form">
   #{rodauth.webauthn_remove_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
-  <fieldset>
-    #{rodauth.account_webauthn_usage.map.with_index do |(id, last_use), i|
-      input = rodauth.input_field_string(rodauth.webauthn_remove_param, "rodauth-webauthn-remove-#{h id}", :type=>'radio', :skip_error_message=>true, :value=>id, :required=>false)
-      "<label class=\"rodauth-webauthn-id\">#{input} Last Use: #{last_use}</label>"
+  <fieldset class="form-group">
+    #{rodauth.account_webauthn_usage.map do |id, last_use|
+      input = "<input type=\"radio\" name=\"#{rodauth.webauthn_remove_param}\" value=\"#{id}\" id=\"rodauth-webauthn-remove-#{h id}\" class=\"form-check-input\"/>"
+      "<div class=\"form-check radio\">#{input}<label class=\"rodauth-webauthn-id form-check-label\" for=\"rodauth-webauthn-remove-#{h id}\">Last Use: #{last_use}</label></div>"
       end.join("\n")}
     #{rodauth.formatted_field_error(rodauth.webauthn_remove_param)}
   </fieldset>

--- a/templates/webauthn-setup.str
+++ b/templates/webauthn-setup.str
@@ -1,4 +1,4 @@
-<form method="post" class="rodauth form-horizontal" role="form" id="rodauth-webauthn-setup-form" data-credential-options="#{h((cred = rodauth.new_webauthn_credential).as_json.to_json)}">
+<form method="post" class="rodauth" role="form" id="rodauth-webauthn-setup-form" data-credential-options="#{h((cred = rodauth.new_webauthn_credential).as_json.to_json)}">
   #{rodauth.webauthn_setup_additional_form_tags}
   #{rodauth.csrf_tag}
   <input type="hidden" name="#{rodauth.webauthn_setup_challenge_param}" value="#{cred.challenge}" />


### PR DESCRIPTION
This pull request updates templates to be compatible with Bootstrap 4, while retaining Bootstrap 3 compatibility as much as possible:

* add [server-side validation errors](https://getbootstrap.com/docs/4.4/components/forms/#server-side) using `is-invalid` and `invalid-feedback` classes
* use [`form-control-plaintext`](https://getbootstrap.com/docs/4.4/components/forms/#readonly-plain-text) class when displaying entered login during multi-phase login (and use `form-control-static` for Bootstrap 3)
* update radio buttons and checkboxes markup with inputs and labels being side-by-side instead of input being the child of the label (the latter is not mentioned anymore in Bootstrap 4 docs)
* wrap `col-*` divs with `row` divs to avoid an indent margin

As we've discussed on the google group, to avoid current alignment issues with horizontal forms, we switch to regular forms which makes it easier to have consistent design and reduces markup.

I've tried to maintain Bootstrap 3 compatibility, and everything looks good to me except that radio buttons and checkboxes have negative margins, which are added by the `radio` class. This class is needed to provide appropriate spacing, but unfortunately I wasn't able to cancel the negative margin because Boostrap 3 doesn't yet have margin utility classes.

I've also done some other related changes:

* extracted the global logout checkbox into a partial due to increased amount of markup
* used `btn-danger` for close account button, as I believe that's more appropriate
* removed `with_index` in the webauthn remove form since the index didn't seem to be used