### PR TITLE
Allow passing query parameters to *_path and *_url methods

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1029,9 +1029,11 @@ authenticated_webauthn_id :: (webauthn feature) If the current session was
                              authenticated via webauthn, the webauthn id of the
                              credential used.
 *_path :: One of these is added for each of the routes added by Rodauth, giving the
-          relative path to the route.
+          relative path to the route. Any options passed to this method will be
+          converted into query parameters.
 *_url :: One of these is added for each of the routes added by Rodauth, giving the
-         URL to the route.
+         URL to the route. Any options passed to this method will be converted
+         into query parameters.
 
 === With Multiple Configurations
 

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -109,8 +109,8 @@ module Rodauth
       route_meth = :"#{name}_route"
       auth_value_method route_meth, default
 
-      define_method(:"#{name}_path") { route_path(send(route_meth)) }
-      define_method(:"#{name}_url") { route_url(send(route_meth)) }
+      define_method(:"#{name}_path") { |*args| route_path(send(route_meth), *args) }
+      define_method(:"#{name}_url") { |*args| route_url(send(route_meth), *args) }
 
       handle_meth = :"handle_#{name}"
       internal_handle_meth = :"_#{handle_meth}"

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -463,12 +463,14 @@ module Rodauth
       request.redirect(path)
     end
 
-    def route_path(route)
-      "#{prefix}/#{route}"
+    def route_path(route, opts={})
+      path  = "#{prefix}/#{route}"
+      path += "?#{Rack::Utils.build_nested_query(opts)}" if opts.any?
+      path
     end
 
-    def route_url(route)
-      "#{base_url}#{route_path(route)}"
+    def route_url(route, opts={})
+      "#{base_url}#{route_path(route, opts)}"
     end
 
     def transaction(opts={}, &block)

--- a/lib/rodauth/features/email_base.rb
+++ b/lib/rodauth/features/email_base.rb
@@ -51,7 +51,7 @@ module Rodauth
     end
 
     def token_link(route, param, key)
-      "#{route_url(route)}?#{param}=#{account_id}#{token_separator}#{convert_email_token_key(key)}"
+      route_url(route, param => "#{account_id}#{token_separator}#{convert_email_token_key(key)}")
     end
 
     def convert_email_token_key(key)

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -60,6 +60,60 @@ describe 'Rodauth' do
     page.title.must_equal 'FooRP'
   end
 
+  it "should support route paths and URLs with prefix and query parameters" do
+    block = proc{''}
+    prefix = ''
+
+    rodauth do
+      enable :login
+      prefix { prefix }
+    end
+    roda do |r|
+      view :content=>instance_exec(&block)
+    end
+
+    block = proc{rodauth.login_path}
+    visit '/'
+    page.text.must_equal '/login'
+
+    prefix = '/auth'
+    visit '/'
+    page.text.must_equal '/auth/login'
+
+    block = proc{rodauth.login_path(a: 'b c')}
+    visit '/'
+    page.text.must_equal '/auth/login?a=b+c'
+
+    block = proc{rodauth.login_path(a: 'b', c: 'd')}
+    visit '/'
+    page.text.must_equal '/auth/login?a=b&c=d'
+
+    block = proc{rodauth.login_path(a: ['b', 'c'])}
+    visit '/'
+    page.text.must_equal '/auth/login?a[]=b&a[]=c'
+
+    block = proc{rodauth.login_url}
+    prefix = ''
+    visit '/'
+    page.text.must_equal 'http://www.example.com/login'
+
+    prefix = '/auth'
+    visit '/'
+    page.text.must_equal 'http://www.example.com/auth/login'
+
+    block = proc{rodauth.login_url(a: 'b c')}
+    visit '/'
+    page.text.must_equal 'http://www.example.com/auth/login?a=b+c'
+
+    block = proc{rodauth.login_url(a: 'b', c: 'd')}
+    visit '/'
+    page.text.must_equal 'http://www.example.com/auth/login?a=b&c=d'
+
+    block = proc{rodauth.login_url(a: ['b', 'c'])}
+    visit '/'
+    page.text.must_equal 'http://www.example.com/auth/login?a[]=b&a[]=c'
+  end
+
   it "should support translation" do
     rodauth do
       enable :login


### PR DESCRIPTION
As discussed on the google group, this PR adds the ability for `*_path` and `*_url` methods to accept query parameters. This allows one to replace:

```rb
"#{rodauth.create_account_path}?#{Rack::Utils.build_nested_query(foo: "bar")}"
#=> "/create-account?foo=bar"
```

with

```rb
rodauth.create_account_path(foo: "bar")
#=> "/create-account?foo=bar"
```

I needed this in my application where I wanted to customize the registration form depending on the context, which I'm passing as query parameters. And Rails didn't have any helper methods for adding query parameters to a path, so I thought it would be useful to Rodauth to have that built in.