### PR TITLE
Ensure webauthn-remove error message is displayed on Bootstrap 4

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -175,6 +175,8 @@ module Rodauth
         value = opts.fetch(:value){scope.h param(param)}
       end
 
+      field_class = opts.fetch(:class, "form-control")
+
       if autocomplete_for_field?(param) && opts[:autocomplete]
         autocomplete = "autocomplete=\"#{opts[:autocomplete]}\""
       end
@@ -187,7 +189,7 @@ module Rodauth
         required = "required=\"required\""
       end
 
-      "<input #{opts[:attr]} #{autocomplete} #{inputmode} #{required} #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"form-control#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\"/> #{formatted_field_error(param) unless opts[:skip_error_message]}"
+      "<input #{opts[:attr]} #{autocomplete} #{inputmode} #{required} #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"#{field_class}#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\"/> #{formatted_field_error(param) unless opts[:skip_error_message]}"
     end
 
     def autocomplete_for_field?(_param)

--- a/templates/webauthn-remove.str
+++ b/templates/webauthn-remove.str
@@ -3,11 +3,12 @@
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
   <fieldset class="form-group">
-    #{rodauth.account_webauthn_usage.map do |id, last_use|
-      input = "<input type=\"radio\" name=\"#{rodauth.webauthn_remove_param}\" value=\"#{id}\" id=\"webauthn-remove-#{h id}\" class=\"form-check-input\"/>"
-      "<div class=\"form-check radio\">#{input}<label class=\"rodauth-webauthn-id form-check-label\" for=\"webauthn-remove-#{h id}\">Last Use: #{last_use}</label></div>"
+    #{(usage = rodauth.account_webauthn_usage).map do |id, last_use|
+      input = rodauth.input_field_string(rodauth.webauthn_remove_param, "webauthn-remove-#{h id}", :type=>'radio', :class=>"form-check-input", :skip_error_message=>true, :value=>id, :required=>false)
+      label = "<label class=\"rodauth-webauthn-id form-check-label\" for=\"webauthn-remove-#{h id}\">Last Use: #{last_use}</label>"
+      error = rodauth.formatted_field_error(rodauth.webauthn_remove_param) if id == usage.keys.last
+      "<div class=\"form-check radio\">#{input}#{label}#{error}</div>"
       end.join("\n")}
-    #{rodauth.formatted_field_error(rodauth.webauthn_remove_param)}
   </fieldset>
   #{rodauth.button(rodauth.webauthn_remove_button)}
 </form>


### PR DESCRIPTION
As described [here](https://groups.google.com/d/msg/rodauth/j3Qc2N1R1MU/xikp41F8AQAJ), the Bootstrap 4 change introduced a regression regarding displaying the validation error message.

Bootstrap 4 requires the input field to have class `is-invalid` and to be a sibling to the `invalid-feedback` element, otherwise the `invalid-feedback` element won't be displayed.

Since the webauthn remove field error will only be displayed if no options were selected, we display the error message after the last radio button. We also use the `#input_field_string` method to get the `is-invalid` class back, but modify it to allow for checkboxes as well.

The tests are failing with this change, it seems the radio buttons are not being displayed anymore on the validation error.
