### PR TITLE
Improvements to the http_basic_auth feature

### DIFF
--- a/doc/http_basic_auth.rdoc
+++ b/doc/http_basic_auth.rdoc
@@ -6,4 +6,4 @@ described in RFC 1945.
 == Auth Value Methods
 
 http_basic_auth_realm :: The realm to return in the WWW-Authenticate header.
-require_http_basic_auth :: If true, when +rodauth.require_authentication+ is used, return a 401 status if basic auth has not been provided, instead of redirecting to the login page. False by default.
+require_http_basic_auth? :: If true, when +rodauth.require_authentication+ is used, return a 401 status if basic auth has not been provided, instead of redirecting to the login page. False by default.

--- a/doc/http_basic_auth.rdoc
+++ b/doc/http_basic_auth.rdoc
@@ -3,6 +3,10 @@
 The HTTP basic auth feature allows logins using HTTP basic authentication,
 described in RFC 1945.
 
+In your routing block, you can require HTTP basic authentication via:
+
+  rodauth.require_http_basic_auth
+
 If you want to allow HTTP basic authentication but not require it, you can
 call:
 

--- a/doc/http_basic_auth.rdoc
+++ b/doc/http_basic_auth.rdoc
@@ -3,6 +3,11 @@
 The HTTP basic auth feature allows logins using HTTP basic authentication,
 described in RFC 1945.
 
+If you want to allow HTTP basic authentication but not require it, you can
+call:
+
+  rodauth.http_basic_auth
+
 == Auth Value Methods
 
 http_basic_auth_realm :: The realm to return in the WWW-Authenticate header.

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -3,7 +3,7 @@
 module Rodauth
   Feature.define(:http_basic_auth, :HttpBasicAuth) do
     auth_value_method :http_basic_auth_realm, "protected"
-    auth_value_method :require_http_basic_auth, false
+    auth_value_method :require_http_basic_auth?, false
 
     def session
       return @session if defined?(@session)
@@ -41,7 +41,7 @@ module Rodauth
     end
 
     def require_login
-      if !logged_in? && require_http_basic_auth
+      if !logged_in? && require_http_basic_auth?
         set_http_basic_auth_error_response
         request.halt
       end

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -6,16 +6,20 @@ module Rodauth
     auth_value_method :require_http_basic_auth?, false
 
     def require_login
-      if !logged_in? && require_http_basic_auth?
-        http_basic_auth
-
-        unless logged_in?
-          set_http_basic_auth_error_response
-          request.halt
-        end
+      if require_http_basic_auth?
+        require_http_basic_auth
       end
 
       super
+    end
+
+    def require_http_basic_auth
+      http_basic_auth
+
+      unless logged_in?
+        set_http_basic_auth_error_response
+        request.halt
+      end
     end
 
     def http_basic_auth

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -42,7 +42,7 @@ module Rodauth
 
         transaction do
           before_login
-          session[session_key] = account_session_value
+          login_session('password')
           after_login
         end
       end

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -5,48 +5,47 @@ module Rodauth
     auth_value_method :http_basic_auth_realm, "protected"
     auth_value_method :require_http_basic_auth?, false
 
-    def session
-      return @session if defined?(@session)
-      sess = super
-      return sess if sess[session_key]
-      return sess unless token = ((v = request.env['HTTP_AUTHORIZATION']) && v[/\A *Basic (.*)\Z/, 1])
-      username, password = token.unpack("m*").first.split(/:/, 2)
+    def require_login
+      if !logged_in? && require_http_basic_auth?
+        http_basic_auth
 
-      if username && password
-        catch_error do
-          unless account_from_login(username)
-            throw_basic_auth_error(login_param, no_matching_login_message)
-          end
-
-          before_login_attempt
-          
-          unless open_account?
-            throw_basic_auth_error(login_param, no_matching_login_message)
-          end
-
-          unless password_match?(password)
-            after_login_failure
-            throw_basic_auth_error(password_param, invalid_password_message)
-          end
-          
-          transaction do
-            before_login
-            sess[session_key] = account_session_value
-            after_login
-          end
+        unless logged_in?
+          set_http_basic_auth_error_response
+          request.halt
         end
       end
 
-      sess
+      super
     end
 
-    def require_login
-      if !logged_in? && require_http_basic_auth?
-        set_http_basic_auth_error_response
-        request.halt
-      end
+    def http_basic_auth
+      return unless token = ((v = request.env['HTTP_AUTHORIZATION']) && v[/\A *Basic (.*)\Z/, 1])
 
-      super
+      username, password = token.unpack("m*").first.split(/:/, 2)
+      return unless username && password
+
+      catch_error do
+        unless account_from_login(username)
+          throw_basic_auth_error(login_param, no_matching_login_message)
+        end
+
+        before_login_attempt
+
+        unless open_account?
+          throw_basic_auth_error(login_param, no_matching_login_message)
+        end
+
+        unless password_match?(password)
+          after_login_failure
+          throw_basic_auth_error(password_param, invalid_password_message)
+        end
+
+        transaction do
+          before_login
+          session[session_key] = account_session_value
+          after_login
+        end
+      end
     end
 
     private

--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -62,10 +62,10 @@ describe "Rodauth http basic auth feature" do
     end
   end
 
-  it "requires authentication if require_http_basic_auth is true" do
+  it "requires authentication if require_http_basic_auth? is true" do
     rodauth do
       enable :http_basic_auth
-      require_http_basic_auth true
+      require_http_basic_auth? true
     end
     roda do |r|
       rodauth.require_authentication

--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -30,35 +30,39 @@ describe "Rodauth http basic auth feature" do
       roda do |r|
         rodauth.http_basic_auth
         r.rodauth
-        r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
+        if rodauth.logged_in?
+          view :content=>"Logged In via #{rodauth.authenticated_by.join(' and ')}"
+        else
+          view :content=>"Not Logged In"
+        end
       end
     end
 
     it "handles logins" do
       basic_auth_visit
-      page.text.must_include "Logged In"
+      page.text.must_include "Logged In via password"
     end
 
     it "keeps the user logged in" do
       visit '/'
-      page.text.must_include "Not Logged"
+      page.text.must_include "Not Logged In"
 
       basic_auth_visit
-      page.text.must_include "Logged In"
+      page.text.must_include "Logged In via password"
 
       visit '/'
-      page.text.must_include "Logged In"
+      page.text.must_include "Logged In via password"
     end
 
     it "fails when no login is found" do
       basic_auth_visit(:username => "foo2@example.com")
-      page.text.must_include "Not Logged"
+      page.text.must_include "Not Logged In"
       page.response_headers.keys.must_include("WWW-Authenticate")
     end
 
     it "fails when passowrd does not match" do
       basic_auth_visit(:password => "1111111111")
-      page.text.must_include "Not Logged"
+      page.text.must_include "Not Logged In"
       page.response_headers.keys.must_include("WWW-Authenticate")
     end
   end
@@ -70,7 +74,11 @@ describe "Rodauth http basic auth feature" do
     end
     roda do |r|
       rodauth.require_authentication
-      r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
+      if rodauth.logged_in?
+        view :content=>"Logged In via #{rodauth.authenticated_by.join(' and ')}"
+      else
+        view :content=>"Not Logged In"
+      end
     end
 
     visit '/'
@@ -78,7 +86,7 @@ describe "Rodauth http basic auth feature" do
     page.response_headers.keys.must_include("WWW-Authenticate")
 
     basic_auth_visit
-    page.text.must_include "Logged In"
+    page.text.must_include "Logged In via password"
   end
 
   it "works with standard authentication" do
@@ -87,7 +95,7 @@ describe "Rodauth http basic auth feature" do
     end
     roda do |r|
       r.rodauth
-      r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
+      r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged In')}
     end
 
     login
@@ -102,12 +110,12 @@ describe "Rodauth http basic auth feature" do
     roda do |r|
       rodauth.http_basic_auth
       r.rodauth
-      r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
+      r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged In')}
     end
     DB[:accounts].update(:status_id=>1)
 
     basic_auth_visit
-    page.text.must_include "Not Logged"
+    page.text.must_include "Not Logged In"
     page.response_headers.keys.must_include("WWW-Authenticate")
   end
 

--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -28,6 +28,7 @@ describe "Rodauth http basic auth feature" do
         enable :http_basic_auth
       end
       roda do |r|
+        rodauth.http_basic_auth
         r.rodauth
         r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
       end
@@ -99,6 +100,7 @@ describe "Rodauth http basic auth feature" do
       skip_status_checks? false
     end
     roda do |r|
+      rodauth.http_basic_auth
       r.rodauth
       r.root{view :content=>(rodauth.logged_in? ? "Logged In" : 'Not Logged')}
     end
@@ -114,6 +116,7 @@ describe "Rodauth http basic auth feature" do
       enable :http_basic_auth
     end
     roda(:jwt) do |r|
+      rodauth.http_basic_auth
       r.rodauth
       response['Content-Type'] = 'application/json'
       rodauth.require_authentication


### PR DESCRIPTION
As discussed on the google group, this introduced couple of fixes and improvements for the http_basic_auth feature.

First, it renames the boolean `#require_http_basic_auth` method to `#require_http_basic_auth?` for consistency with other boolean auth value methods.

Next, I wanted to call `#login_session` when logging in, so that things like `#authenticated_by` are properly set which other features rely on. However, I couldn't do so when we were overriding `#session`, because `#login_session` calls `#session` internally, which created an endless loop.

So I decided to extract this behaviour into a `#http_basic_auth` method. Now, instead of HTTP basic authentication being allowed for any request that calls `#session`, the developer needs to call `#http_basic_auth` in their routing tree to get that behaviour (I find this nicer as it's more explicit):

```rb
route do |r|
  rodauth.http_basic_auth
  r.rodauth
  # ...
end
```

Lastly, I've extracted requiring HTTP basic authentication into a new `#require_http_basic_auth` method, which IMO fits nicely with other `#require_*` methods. Now the developer can call `#require_http_basic_auth` when they want to require HTTP basic authentication, and `#http_basic_auth` when they want to allow it but not require it.

I should probably write more thorough specs for `#http_basic_auth`; e.g. the way it's currently written it allows re-logging in without logging out first, which could be a useful feature that someone might rely on in the future. I should also write specs for `#require_http_basic_auth`, as it's a public-facing method.

Firstly I wanted to check with you whether you agree with this direction.