### PR TITLE
Don't call #check_already_logged_in in verify_login_change

### DIFF
--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -50,7 +50,6 @@ module Rodauth
     )
 
     route do |r|
-      check_already_logged_in
       before_verify_login_change_route
 
       r.get do


### PR DESCRIPTION
When verifying login change, the user is expected to be logged in, because prior to that they've changed their login, which required them to be logged in. This action also does generally make sense when the user is logged in.

In my case, this allows me to configure

```rb
already_logged_in { redirect login_redirect }
```

and have that be called for login, create_account and reset_password, but still allow access to the verify_login_change page.
