### PR TITLE
Generate unlock account key outside of #send_unlock_account_email

### DIFF
--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -73,6 +73,7 @@ module Rodauth
             redirect unlock_account_email_recently_sent_redirect
           end
 
+          @unlock_account_key_value = get_unlock_account_key
           transaction do
             before_unlock_account_request
             set_unlock_account_email_last_sent
@@ -215,7 +216,6 @@ module Rodauth
     end
 
     def send_unlock_account_email
-      @unlock_account_key_value = get_unlock_account_key
       send_email(create_unlock_account_email)
     end
 


### PR DESCRIPTION
This makes it easier to override `#send_unlock_account_email` with custom email sending, as it means that calling `#unlock_account_email_link` will just work, just like with other `#send_*_email` methods (see [rodauth-rails recommendation](https://github.com/janko/rodauth-rails/blob/7562530ea78cbf7a8bbffa8208915a0623473c1a/lib/generators/rodauth/templates/lib/rodauth_app.rb#L44-L61)).

Previously trying to call `#unlock_account_email_link` inside overridden `#send_unlock_account_email` would return an email link with empty token value, because the `@unlock_account_key_value` variable wasn't being set.