### PR TITLE
Don't consider account open if in unverified grace period without password

### DIFF
--- a/lib/rodauth/features/verify_account_grace_period.rb
+++ b/lib/rodauth/features/verify_account_grace_period.rb
@@ -23,7 +23,7 @@ module Rodauth
     end
 
     def open_account?
-      super || account_in_unverified_grace_period?
+      super || (account_in_unverified_grace_period? && has_password?)
     end
 
     def verify_account_set_password?

--- a/spec/verify_account_grace_period_spec.rb
+++ b/spec/verify_account_grace_period_spec.rb
@@ -140,6 +140,28 @@ describe 'Rodauth verify_account_grace_period feature' do
     page.body.must_include('Logged Intrue')
   end
 
+  it "should not allow login when password was not set" do
+    rodauth do
+      enable :login, :logout, :verify_account_grace_period
+      verify_account_set_password? true
+    end
+    roda do |r|
+      r.rodauth
+      r.root{view :content=>rodauth.logged_in? ? "Logged In#{rodauth.verified_account?}" : "Not Logged"}
+    end
+
+    visit '/create-account'
+    fill_in 'Login', :with=>'foo@example2.com'
+    click_button 'Create Account'
+    link = email_link(/(\/verify-account\?key=.+)$/, 'foo@example2.com')
+
+    logout
+    visit '/login'
+    fill_in 'Login', :with=>'foo@example2.com'
+    click_button 'Login'
+    page.find('#error_flash').text.must_equal "The account you tried to login with is currently awaiting verification"
+  end
+
   it "should remove verify keys if closing unverified accounts" do
     rodauth do
       enable :login, :close_account, :verify_account_grace_period


### PR DESCRIPTION
When the account is in the unverified grace period, but its password has not yet been set (i.e. `verify_account_set_password?` was set to true, delaying setting password until account verification), we should ensure that we prevent logins for this account.

I originally thought it's possible to log in to such account without password, but it seems that login already won't work in this case, because `#password_match?` method requires that the account has set password. However, in this case the user will get an "invalid password" error message, which is not exactly accurate.

I think it's safer to explicitly handle this scenario and not consider the account open in this case, which returns the correct error message that the account is awaiting verification. Essentially, if you're using verify_account_grace_period and delaying password set (i.e. setting `verify_account-set_password?` to true), you can only use the account unverified until the session expires, which is reasonable to me.
