### PR TITLE
Don't consider account open if in unverified grace period without password

### DIFF
--- a/lib/rodauth/features/verify_account_grace_period.rb
+++ b/lib/rodauth/features/verify_account_grace_period.rb
@@ -23,7 +23,7 @@ module Rodauth
     end
 
     def open_account?
-      super || account_in_unverified_grace_period?
+      super || (account_in_unverified_grace_period? && has_password?)
     end
 
     def verify_account_set_password?


### PR DESCRIPTION
I found another angle for https://github.com/jeremyevans/rodauth/pull/91 where this change is useful, so I would like to propose this change again (I would re-open that PR but I had deleted that branch, so GitHub didn't allow it).

In https://github.com/jeremyevans/rodauth/pull/91 we discussed that, in case a user is in an unverified grace period and doesn't have a password (i.e. `verify_account_set_password?` was intentionally set to `true`), attempting to login to that account will return an error message that the password was invalid. I had agreed this behaviour seemed good enough, because I thought the only important thing is to prevent the login.

However, I realized that based on this error message the user might not realize they need to verify their account, because nothing in that error message indicates this (instead it suggests that the password is the issue). The default login page does show a link to resend account verification email, however, (a) the user might not see it, or (b) it might not be there at when using a custom login page.

Returning false in `#open_account?` when the user is in unverified grace period and hasn't set their password would instead have the `#before_login_attempt` method show a form for re-sending account verification email, letting the user know they need to verify their account to proceed in the flash error message. I believe this providers better UX.