### PR TITLE
Move checking CSRF token into #check_csrf method

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -91,6 +91,7 @@ authenticated? :: Whether the user has been authenticated. If multifactor authen
 before_login :: Run arbitrary code after password has been checked, but before updating the session.
 before_login_attempt :: Run arbitrary code after an account has been located, but before the password has been checked.
 before_rodauth :: Run arbitrary code before handling any rodauth route, but after CSRF checks if Rodauth is doing CSRF checks.
+check_csrf :: Checks CSRF token using Roda's +check_csrf!+ method.
 clear_session :: Clears the current session.
 csrf_tag(path=request.path) :: The HTML fragment containing the CSRF tag to use, if any.
 function_name(name) :: The name of the database function to call.  It's passed either :rodauth_get_salt or :rodauth_valid_password_hash.

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -119,7 +119,7 @@ module Rodauth
 
       define_method(handle_meth) do
         request.is send(route_meth) do
-          scope.check_csrf!(check_csrf_opts, &check_csrf_block) if check_csrf?
+          check_csrf if check_csrf?
           before_rodauth
           send(internal_handle_meth, request)
         end

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -82,6 +82,7 @@ module Rodauth
       :already_logged_in,
       :authenticated?,
       :autocomplete_for_field?,
+      :check_csrf,
       :clear_session,
       :csrf_tag,
       :function_name,
@@ -331,6 +332,10 @@ module Rodauth
 
     def account_from_session
       @account = _account_from_session
+    end
+
+    def check_csrf
+      scope.check_csrf!(check_csrf_opts, &check_csrf_block)
     end
 
     def csrf_tag(path=request.path)


### PR DESCRIPTION
This allows the CSRF checking logic to be overridden. For example, rodauth-rails gem can now override this method to use Action Controller for checking CSRF tokens. This means when the user or a 3rd-party gem wants to disable CSRF protection for certain routes, they can have `#check_csrf?` return false for those routes, and that would work with rodauth-rails as well (currently rodauth-rails overrides `#before_rodauth` to do its CSRF protection).

cc @HoneyryderChuck
