### PR TITLE
Use 'new-password' on create-account template

### DIFF
--- a/templates/create-account.str
+++ b/templates/create-account.str
@@ -3,7 +3,12 @@
   #{rodauth.csrf_tag}
   #{rodauth.render('login-field')}
   #{rodauth.render('login-confirm-field') if rodauth.require_login_confirmation?}
-  #{rodauth.render('password-field') if rodauth.create_account_set_password?}
+  #{if rodauth.create_account_set_password?}
+    <div class="form-group">
+      <label for="password">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
+      #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>'new-password')}
+    </div>
+  #{end}
   #{rodauth.render('password-confirm-field') if rodauth.create_account_set_password? && rodauth.require_password_confirmation?}
   #{rodauth.button(rodauth.create_account_button)}
 </form>


### PR DESCRIPTION
On /create-account, the password-field should be `autocomplete='new-password'` in order for browser to suggest new secure password

![Screenshot 2020-06-03 at 03 39 50](https://user-images.githubusercontent.com/1242610/83586454-c76b0a80-a54c-11ea-8041-d0b3211b8f34.png)

Unfortunately there is some copy/paste from password-field.str, so I am not sure it is the best implementation.

Not sure if there should be a new `new-password-field.str`... Or if it is not a required feature and in this case feel free to cancel the PR 👍

In my specific case, I use https://github.com/janko/rodauth-rails and I overrided the views in order to send a parameter to `<%= render "password_field", create_account: true %>` and then use `local_assigns` to choose between `new-password` or `current-password`