### PR TITLE
Don't check CSRF token on JSON requests

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -140,6 +140,11 @@ module Rodauth
 
     private
 
+    def check_csrf?
+      return false if json_request?
+      super
+    end
+
     def before_rodauth
       if json_request?
         if jwt_check_accept? && (accept = request.env['HTTP_ACCEPT']) && accept !~ json_accept_regexp

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -106,6 +106,21 @@ describe 'Rodauth login feature' do
     page.find('#notice_flash').text.must_equal 'You have been logged in'
   end
 
+  it "should not check CSRF for json requests" do
+    rodauth do
+      enable :login, :jwt
+      jwt_secret '1'
+      only_json? false
+    end
+    roda(:jwt_html) do |r|
+      r.rodauth
+      view(:content=>'1')
+    end
+
+    res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
+    res.must_equal true
+  end
+
   it "should require POST for json requests" do
     rodauth do
       enable :login, :logout, :jwt


### PR DESCRIPTION
JSON requests should probably not be expected to provide a CSRF token, because CSRF protection is normally not part of a JSON API. This makes JSON requests in Rodauth with both HTML and JWT route versions enabled (i.e. with `json: true`) work automatically, the user doesn't need to disable CSRF protection for JSON routes.

/cc @nicolas-besnard