### PR TITLE
Add "How-To" articles for common scenarios

### DIFF
--- a/doc/howto/admin_activation.rdoc
+++ b/doc/howto/admin_activation.rdoc
@@ -1,0 +1,31 @@
+= How To: Require admin account verification
+
+There are scenarios in which, instead of allowing the user to confirm their
+own created account, you may want to have an admin or moderator activate new
+accounts. This can be achieved by sending the account verification email to the
+admin:
+
+  plugin :rodauth do
+    # ...
+    # send account verification email to the admin
+    email_to do
+      if account[account_status_column] == account_unverified_status_value
+        "admin@myapp.com"
+      else
+        super()
+      end
+    end
+
+    # adjust the account verification email subject and body
+    verify_account_email_subject "New User Awaiting Admin Approval"
+    verify_account_email_body do
+      "The user #{account[login_column]} has created an account. Click here to approve it: #{verify_account_email_link}."
+    end
+
+    # display this message to the user after they've created their account
+    verify_account_email_sent_notice_flash "Your account has been created and is awaiting approval"
+
+    # prevent the admin from being logged in after confirming the account
+    verify_account_autologin? false
+    verify_account_notice_flash "The account has been approved"
+  end

--- a/doc/howto/already_authenticated.rdoc
+++ b/doc/howto/already_authenticated.rdoc
@@ -1,0 +1,10 @@
+= How To: Skip login page if already authenticated
+
+In some cases it may be useful to skip login/registration pages when the user
+is already logged in. This can be achieved as follows:
+
+  plugin :rodauth do
+    # ...
+    # redirect logged in users to the wherever login redirects to
+    already_logged_in { redirect login_redirect }
+  end

--- a/doc/howto/alternative_login.rdoc
+++ b/doc/howto/alternative_login.rdoc
@@ -1,0 +1,22 @@
+= How To: Use a non-email login
+
+Rodauth's login feature uses the email address for identifying users. In some
+cases, however, you might want to allow logging in via alternative identifiers,
+such as a username.
+
+Let's assume you have a +username+ field on the +accounts+ table, see the
+{Adding new registration field}[rdoc-ref:doc/howto/registration_field.rdoc]
+guide for instructions on how to do that. Then you can modify Rodauth to allow
+entering a username in addition to email on login:
+
+  plugin :rodauth do
+    # ...
+    account_from_login do |login|
+      # handle the case when login parameter is a username
+      unless login.include?("@")
+        login = db[:accounts].where(username: login).get(:email)
+      end
+
+      super(login)
+    end
+  end

--- a/doc/howto/create_account_programmatically.rdoc
+++ b/doc/howto/create_account_programmatically.rdoc
@@ -1,0 +1,25 @@
+= How To: Create an account record programmatically
+
+In some scenarios you might want to create an account records programmatically,
+for example in your tests.
+
+If you're storing passwords in a separate table, you can create an account
+records as follows:
+
+  account_id = DB[:accounts].insert(
+    email:     "name@example.com",
+    status_id: 2, # verified
+  )
+
+  DB[:account_password_hashes].insert(
+    id:            account_id,
+    password_hash: BCrypt::Password.create("secret").to_s,
+  )
+
+Or if the password is stored in a column on the +accounts+ table:
+
+  account_id = DB[:accounts].insert(
+    email:         "name@example.com",
+    password_hash: BCrypt::Password.create("secret").to_s,
+    status_id:     2, # verified
+  )

--- a/doc/howto/delay_password.rdoc
+++ b/doc/howto/delay_password.rdoc
@@ -1,0 +1,14 @@
+= How To: Set password when verifying account
+
+If you want to request less information from the user on registration, you can
+ask the user to set their password only when they verify their account:
+
+  plugin :rodauth do
+    # ...
+    verify_account_set_password? true
+  end
+
+Note that this is already the default behaviour when verify account feature is
+loaded, but it's not when verify account grace period is used. In this case the
+user will have to verify their account if they get logged out, so you might
+want to use the remember feature as well.

--- a/doc/howto/email_only.rdoc
+++ b/doc/howto/email_only.rdoc
@@ -1,0 +1,16 @@
+= How To: Allow only email authentication
+
+When using the email authentication feature, you can avoid other authentication
+mechanisms entirely as follows:
+
+  plugin :rodauth do
+    enable :login, :email_auth, :create_account, :verify_account
+
+    create_account_set_password? false
+    verify_account_set_password? false
+    force_email_auth? true
+  end
+
+With this configuration, users won't be required to enter a password on
+registration, and on login the email auth link will automatically be sent after
+the email address is entered.

--- a/doc/howto/i18n.rdoc
+++ b/doc/howto/i18n.rdoc
@@ -1,0 +1,26 @@
+= How To: Translate with I18n gem
+
+Rodauth allows transforming user-facing text configuration such as flash
+messages, validation errors, labels etc. via the +translate+ configuration
+method. This method receives a name of a configuration along with its default
+value, and is expected to return the result text.
+
+You can use this to perform translations using the
+{I18n gem}[https://github.com/ruby-i18n/i18n]:
+
+  plugin :rodauth do
+    # ...
+    translate do |key, default|
+      I18n.translate("rodauth.#{key}") || default
+    end
+  end
+
+Your translation file may then look something like this:
+
+  en:
+    rodauth:
+      login_notice_flash: "You have been signed in"
+      require_login_error_flash: "Login is required for accessing this page"
+      no_matching_login_message: "user with this email address doesn't exist"
+      reset_password_email_subject: "Password Reset Instructions"
+      # ...

--- a/doc/howto/links.rdoc
+++ b/doc/howto/links.rdoc
@@ -1,0 +1,14 @@
+= How To: Display authentication links
+
+You can retrieve a relative URL to any Rodauth action by calling the
+corresponding `*_path` method on the Rodauth instance:
+
+  link_to "Sign in",  rodauth.login_path
+  link_to "Sign up",  rodauth.create_account_path
+  link_to "Sign out", rodauth.logout_path, method: :post
+
+For absolute URLs call the `*_url` method:
+
+  link_to "Sign in",  rodauth.login_url
+  link_to "Sign up",  rodauth.create_account_url
+  link_to "Sign out", rodauth.logout_url, method: :post

--- a/doc/howto/login_return.rdoc
+++ b/doc/howto/login_return.rdoc
@@ -1,0 +1,56 @@
+= How To: Redirect to original page after login
+
+== When requiring authentication
+
+When the user attempts to open a page that requires authentication, it can be
+useful to redirect them back to the page they originally requested after login.
+You can achieve this as follows:
+
+  plugin :rodauth do
+    # ...
+    login_return_to_requested_location? true
+  end
+
+  route do |r|
+    # ...
+    # clear saved login redirect if the user didn't proceed with login
+    session[rodauth.login_redirect_session_key] = nil
+  end
+
+If you're using multifactor authentication, you'll probably want to set the
+same setting for it as well:
+
+  plugin :rodauth do
+    # ...
+    two_factor_auth_return_to_requested_location? true
+  end
+
+  route do |r|
+    # ...
+    # clear saved MFA redirect if the user didn't proceed with MFA
+    session[rodauth.two_factor_auth_redirect_session_key] = nil
+  end
+
+== When authenticating manually
+
+You may aso want to return the user back in case they've manually clicked on
+the login link. You can do this by saving the current path for each
+non-authentication route:
+
+  route do |r|
+    # ...
+    # return the last visited path after login
+    unless rodauth.logged_in?
+      session[rodauth.login_redirect_session_key] = request.fullpath
+    end
+  end
+
+And for multifactor authentication as well if you're using it:
+
+  route do |r|
+    # ...
+    # return the last visited path after MFA
+    unless rodauth.two_factor_authenticated?
+      session[rodauth.two_factor_auth_redirect_session_key] = request.fullpath
+    end
+  end

--- a/doc/howto/password_column.rdoc
+++ b/doc/howto/password_column.rdoc
@@ -1,0 +1,20 @@
+= How To: Store password hash in accounts table
+
+By default, Rodauth stores the password hash in a separate
++account_password_hashes+ table. However, you can also store the password hash
+directly in the +accounts+ table.
+
+To do this, add the password hash column to the +accounts+ table:
+
+  create_table :accounts do
+    # ...
+    String :password_hash
+  end
+
+And then tell Rodauth to use it:
+
+  plugin :rodauth do
+    # ...
+    # uses the password_hash column on the accounts table
+    account_password_hash_column :password_hash
+  end

--- a/doc/howto/password_confirmation.rdoc
+++ b/doc/howto/password_confirmation.rdoc
@@ -1,0 +1,27 @@
+= How To: Require password confirmation for certain actions
+
+You might want to require the user to enter their password before accessing
+sensitive sections of the app. This functionality is provided by the confirm
+password feature, which accompanied with the password grace period feature will
+remember the entered password for a period of time:
+
+  plugin :rodauth do
+    enable :confirm_password, :password_grace_period
+    password_grace_period 60*60 # remember the password for 1 hour
+  end
+
+  route do |r|
+    # ...
+    if r.path == "/some-action"
+      rodauth.require_password_authentication
+    end
+  end
+
+You can also do this for Rodauth actions that normally require a password,
+which essentially moves the password confirmation into a separate step:
+
+  plugin :rodauth do
+    # ...
+    before_change_login_route    { require_password_authentication }
+    before_change_password_route { require_password_authentication }
+  end

--- a/doc/howto/password_requirements.rdoc
+++ b/doc/howto/password_requirements.rdoc
@@ -1,0 +1,13 @@
+= How To: Customize password requirements
+
+By default, Rodauth requires passwords to have at least 6 characters. You can
+increase the minimum length:
+
+  plugin :rodauth
+    # ...
+    # require passwords to have at least 8 characters
+    password_minimum_length 8
+  end
+
+You can also additional complexity checks on passwords via the {password
+complexity}[rdoc-ref:doc/password_complexity.rdoc] feature.

--- a/doc/howto/paths.rdoc
+++ b/doc/howto/paths.rdoc
@@ -1,0 +1,30 @@
+= How To: Change route path
+
+You can change the URL path of any Rodauth route by overriding the
+corresponding +*_route+ method:
+
+  plugin :rodauth do
+    # ...
+    # change login route to "/signin"
+    login_route "signin"
+    # change create account route to "/register"
+    create_account_route "register"
+    # change password reset request route to "/reset-password-request"
+    reset_password_request_route "reset-password/request"
+  end
+
+If you want to add a prefix to all Rodauth routes, you should use the +prefix+
+setting:
+
+  plugin :rodauth do
+    # ...
+    # add /auth/* path prefix to each Rodauth route
+    prefix "/auth"
+  end
+
+  route do |r|
+    r.on "auth" do
+      r.rodauth
+    end
+    # ...
+  end

--- a/doc/howto/query_params.rdoc
+++ b/doc/howto/query_params.rdoc
@@ -1,0 +1,9 @@
+= How To: Pass query parameters to auth URLs
+
+The `*_path` and `*_url` methods allow passing additional query parameters:
+
+  rodauth.create_account_path(type: "seller")
+  #=> "/create-account?type=seller"
+
+  rodauth.login_url(type: "operator")
+  #=> "https//example.com/login?type=operator"

--- a/doc/howto/redirects.rdoc
+++ b/doc/howto/redirects.rdoc
@@ -1,0 +1,14 @@
+= How To: Change redirect destination
+
+You can change the redirect destination for any Rodauth action by overriding
+the corresponding +*_redirect+ method:
+
+  plugin :rodauth do
+    # ...
+    # redirect to "/dashboard" after login
+    login_redirect "/dashboard"
+    # redirect to wherever login redirects to after creating account
+    create_account_redirect { login_redirect }
+    # redirect to login page after password reset
+    reset_password_redirect { login_path }
+  end

--- a/doc/howto/registration_field.rdoc
+++ b/doc/howto/registration_field.rdoc
@@ -1,0 +1,60 @@
+= How To: Add new registration field
+
+The create account form is only handling email and password parameters by
+default. However, you might often want to ask for additional information on
+registration, such as requiring the user to also enter their full name or their
+company's name.
+
+== A) Accounts table
+
+Let's assume you wanted to wanted to store the additional field(s) directly on
+the `accounts` table:
+
+  create_table :accounts do
+    # ...
+    String :name, null: false
+  end
+
+Given you've added the new field(s) into the create account form, you can
+handle it in a before create account hook:
+
+  plugin :rodauth do
+    # ...
+    before_create_account do
+      # validate presence of the new field
+      throw_error_status(422, "name", "must be present") if param("name").empty?
+      # assign the new field to the account record
+      account[:name] = param("name")
+    end
+  end
+
+== B) Separate table
+
+Alternatively, you can store the additional field(s) in separate table, for
+example:
+
+  create_table :profiles do
+    primary_key :id
+    foreign_key :account_id, :accounts
+    String :name, null: false
+  end
+
+You can then handle the new submitted field as follows:
+
+  plugin :rodauth do
+    # ...
+    before_create_account do
+      # validate presence of the new field
+      throw_error_status(422, "name", "must be present") if param("name").empty?
+    end
+
+    after_create_account do
+      # create the associated record assigning the new field
+      db[:profiles].insert(account_id: account[:id], name: param("name"))
+    end
+
+    after_close_account do
+      # delete the associated record after closing the account
+      db[:profiles].where(account_id: account[:id]).delete
+    end
+  end

--- a/doc/howto/remember_mfa.rdoc
+++ b/doc/howto/remember_mfa.rdoc
@@ -1,0 +1,16 @@
+= How To: Remember multifactor authentication
+
+By default, the +load_memory+ method from remember feature will automatically
+log users in from a cookie, but they will still need to
+multifactor-authenticate if the app requires it.
+
+You can have the remember feature consider remembered users
+multifactor-authenticated as follows:
+
+  plugin :rodauth do
+    # ...
+    # remember login only after successful multifactor authentication
+    after_two_factor_authentication { remember_login }
+    # multifactor-authenticate accounts loaded from memory if MFA is set up
+    after_load_memory { two_factor_update_session("totp") if two_factor_authentication_setup? }
+  end

--- a/doc/howto/require_mfa.rdoc
+++ b/doc/howto/require_mfa.rdoc
@@ -1,0 +1,23 @@
+= How To: Require multifactor authentication after login
+
+You'll likely want to require multifactor authentication on login for people
+that have multifactor authentication set up. The +require_authentication+
+Rodauth method works for pages that require an authenticated user, but not for
+pages where authentication is optional.
+
+You can set this up as follows:
+
+  plugin :rodauth do
+    # ...
+    # no need to display an error flash when redirecting to MFA
+    two_factor_need_authentication_error_flash nil
+    # display a generic notice message after MFA
+    two_factor_auth_notice_flash { login_notice_flash }
+  end
+
+  route do |r|
+    # ...
+    if rodauth.logged_in? && rodauth.two_factor_authentication_setup?
+      rodauth.require_two_factor_authenticated
+    end
+  end

--- a/doc/howto/reset_password_autologin.rdoc
+++ b/doc/howto/reset_password_autologin.rdoc
@@ -1,0 +1,10 @@
+= How To: Autologin after password reset
+
+When the user resets their password, by default they are not automatically
+logged in. You can change this behaviour and login the user after password
+reset:
+
+  plugin :rodauth do
+    # ...
+    reset_password_autologin? true
+  end

--- a/doc/howto/status_column.rdoc
+++ b/doc/howto/status_column.rdoc
@@ -1,0 +1,27 @@
+= How To: Store account status in a text column
+
+By default, Rodauth recommends using a separate table for account statuses, and
+linking them via foreign keys. This is useful as it achieves an enum-like
+behaviour, where the database ensures a constrained set of status values.
+
+However, in development and test environments which start a blank database, it
+may be more convenient to have the account status as a simple text column on
+the +accounts+ table, as that doesn't require any pre-existing records.
+
+We can achieve this by, instead of having a +status_id+ foreign key, we create
+a +status+ text column:
+
+  create_table :accounts do
+    # ...
+    String :status, null: false, default: "verified"
+  end
+
+And then let Rodauth know about our new text-based configuration:
+
+  plugin :rodauth do
+    # ...
+    account_status_column :status
+    account_unverified_status_value "unverified"
+    account_open_status_value "verified"
+    account_closed_status_value "closed"
+  end

--- a/doc/howto/totp_or_recovery.rdoc
+++ b/doc/howto/totp_or_recovery.rdoc
@@ -1,0 +1,14 @@
+= How To: Allow recovery code on TOTP code field
+
+If using multifcator authentication, for convenience you might want to allow
+the user to alternatively enter a recovery code into a TOTP code field. You can
+achieve this as follows:
+
+  plugin :rodauth do
+    # ...
+    before_otp_auth_route do
+      if recovery_code_match?(param(otp_auth_param))
+        two_factor_authenticate("recovery_code")
+      end
+    end
+  end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -51,6 +51,32 @@
   <li><a href="rdoc/files/doc/webauthn_verify_account_rdoc.html">WebAuthn Verify Account</a>: Adds support for passwordless WebAuthn setup during account verification.</li>
 </ul>
 
+<h2 id="how-to">"How-To" articles</h2>
+
+<ul>
+  <li><a href="rdoc/files/doc/howto/admin_activation_rdoc.html">Require admin account verification</a></li>
+  <li><a href="rdoc/files/doc/howto/already_authenticated_rdoc.html">Skip login page if already authenticated</a></li>
+  <li><a href="rdoc/files/doc/howto/alternative_login_rdoc.html">Use a non-email login</a></li>
+  <li><a href="rdoc/files/doc/howto/create_account_programmatically_rdoc.html">Create an account record programmatically</a></li>
+  <li><a href="rdoc/files/doc/howto/delay_password_rdoc.html">Set password when verifying account</a></li>
+  <li><a href="rdoc/files/doc/howto/email_only_rdoc.html">Allow only email authentication</a></li>
+  <li><a href="rdoc/files/doc/howto/i18n_rdoc.html">Translate with I18n gem</a></li>
+  <li><a href="rdoc/files/doc/howto/links_rdoc.html">Display authentication links</a></li>
+  <li><a href="rdoc/files/doc/howto/login_return_rdoc.html">Redirect to original page after login</a></li>
+  <li><a href="rdoc/files/doc/howto/password_column_rdoc.html">Store password hash in accounts table</a></li>
+  <li><a href="rdoc/files/doc/howto/password_confirmation_rdoc.html">Require password confirmation for certain actions</a></li>
+  <li><a href="rdoc/files/doc/howto/password_requirements_rdoc.html">Customize password requirements</a></li>
+  <li><a href="rdoc/files/doc/howto/paths_rdoc.html">Change route path</a></li>
+  <li><a href="rdoc/files/doc/howto/query_params_rdoc.html">Pass query parameters to auth URLs</a></li>
+  <li><a href="rdoc/files/doc/howto/redirects_rdoc.html">Change redirect destination</a></li>
+  <li><a href="rdoc/files/doc/howto/registration_field_rdoc.html">Add new registration field</a></li>
+  <li><a href="rdoc/files/doc/howto/remember_mfa_rdoc.html">Remember multifactor authentication</a></li>
+  <li><a href="rdoc/files/doc/howto/require_mfa_rdoc.html">Require multifactor authentication after login</a></li>
+  <li><a href="rdoc/files/doc/howto/reset_password_autologin_rdoc.html">Autologin after password reset</a></li>
+  <li><a href="rdoc/files/doc/howto/status_column_rdoc.html">Store account status in a text column</a></li>
+  <li><a href="rdoc/files/doc/howto/totp_or_recovery_rdoc.html">Allow recovery code on TOTP code field</a></li>
+</ul>
+
 <h2 id="other-doc">Other Documentation</h2>
 
 <ul>


### PR DESCRIPTION
Currently Rodauth feature documentation is mainly a reference of all configuration methods, which is good for people already familiar with Rodauth, but can be challenging for people just starting out.

So, as we discussed, I wrote some "How-To" articles for various use cases that are commonly found, which should hopefully help people achieve what they want more easily. These guides are inspired by the ["How-To" articles in the Devise wiki](https://github.com/heartcombo/devise/wiki/How-Tos).

They're in a format of short and focused tips, most of which I haven't actually tested, but figured they should work from my knowledge of Rodauth's source code. Since they're of different nature than the internals guide, I thought it would make sense to put them in a separate section.