### PR TITLE
Reduce queries in #authenticated? and #require_authentication

### DIFF
--- a/lib/rodauth/features/two_factor_base.rb
+++ b/lib/rodauth/features/two_factor_base.rb
@@ -125,7 +125,7 @@ module Rodauth
       return true if two_factor_authenticated?
 
       # True if authenticated via single factor and 2nd factor not setup 
-      !two_factor_authentication_setup?
+      !uses_two_factor_authentication?
     end
 
     def require_authentication
@@ -134,7 +134,7 @@ module Rodauth
       # Avoid database query if already authenticated via 2nd factor
       return if two_factor_authenticated?
 
-      require_two_factor_authenticated if two_factor_authentication_setup?
+      require_two_factor_authenticated if uses_two_factor_authentication?
     end
 
     def require_two_factor_setup


### PR DESCRIPTION
Both of these methods call `#two_factor_authentication_setup?`, which calls `#possible_authentication_methods`, which makes additional queries. These queries are cached during a single request, but are run on every new request. It will run 1 query to load the password, and 1 query for each loaded MFA feature (OTP, SMS codes, Recovery codes etc), which puts some load on the database.

So, I thought we could changes these methods to call `#uses_two_factor_authentication?` instead, which caches the result of `#two_factor_authentication_setup?` in a session key, which persists between requests. This means `#authenticated?` and `#require_authentication` won't run any queries once the result is cached.
