### PR TITLE
Make validating login email more configurable

### DIFF
--- a/doc/login_password_requirements_base.rdoc
+++ b/doc/login_password_requirements_base.rdoc
@@ -9,8 +9,10 @@ already_an_account_with_this_login_message :: The error message to display when 
 login_confirm_label :: The label to use for login confirmations.
 login_confirm_param :: The parameter name to use for login confirmations.
 login_does_not_meet_requirements_message :: The error message to display when the login does not meet the requirements you have set.
+login_email_regexp :: The regular expression used to validate whether login is a valid email address.
 login_maximum_length :: The maximum length for logins, 255 by default.
 login_minimum_length :: The minimum length for logins, 3 by default.
+login_not_valid_email_message :: The error message to display when login is not a valid email address.
 login_too_long_message :: The error message fragment to show if the login is too long.
 login_too_short_message :: The error message fragment to show if the login is too short.
 logins_do_not_match_message :: The error message to display when login and login confirmation do not match.
@@ -29,6 +31,7 @@ same_as_existing_password_message :: The error message to display when a new pas
 == Auth Methods
 
 login_meets_requirements?(login) :: Whether the given login meets the requirements.  By default, just checks that the login is a valid email address.
+login_valid_email?(login) :: Whether the login is a valid email address.
 password_hash(password) :: A hash of the given password.
 password_meets_requirements?(password) :: Whether the given password meets the requirements. Can be used to implement complexity requirements for passwords.
 set_password(password) :: Set the password for the current account to the given password.

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -4,8 +4,10 @@ module Rodauth
   Feature.define(:login_password_requirements_base, :LoginPasswordRequirementsBase) do
     translatable_method :already_an_account_with_this_login_message, 'already an account with this login'
     auth_value_method :login_confirm_param, 'login-confirm'
+    auth_value_method :login_email_regexp, /\A[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+\z/
     auth_value_method :login_minimum_length, 3
     auth_value_method :login_maximum_length, 255
+    translatable_method :login_not_valid_email_message, 'not a valid email address'
     translatable_method :logins_do_not_match_message, 'logins do not match'
     auth_value_method :password_confirm_param, 'password-confirm'
     auth_value_method :password_minimum_length, 6
@@ -28,6 +30,7 @@ module Rodauth
 
     auth_methods(
       :login_meets_requirements?,
+      :login_valid_email?,
       :password_hash,
       :password_meets_requirements?,
       :set_password
@@ -104,11 +107,13 @@ module Rodauth
 
     def login_meets_email_requirements?(login)
       return true unless require_email_address_logins?
-      if login =~ /\A[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+\z/
-        return true
-      end
-      @login_requirement_message = 'not a valid email address'
+      return true if login_valid_email?(login)
+      @login_requirement_message = login_not_valid_email_message
       return false
+    end
+
+    def login_valid_email?(login)
+      login =~ login_email_regexp
     end
 
     def password_meets_length_requirements?(password)


### PR DESCRIPTION
Most authentication frameworks allow overriding the email regex, so I thought we could add that setting here as well:

```rb
# uses the email_validator gem
login_email_regexp EmailValidator.regexp
```

I think it's also useful to allow overriding the method that validates the email, for when we want more complex validation than just using a regex:

```rb
# uses the truemail gem
login_valid_email? { |login| Truemail.valid?(login) }
```

Finally, I also extracted the validation error for when login is not a valid email address:

```rb
login_not_valid_email_message "not a valid email address"
```
