### PR TITLE
Update anchor link for "Guides" heading

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -51,7 +51,7 @@
   <li><a href="rdoc/files/doc/webauthn_verify_account_rdoc.html">WebAuthn Verify Account</a>: Adds support for passwordless WebAuthn setup during account verification.</li>
 </ul>
 
-<h2 id="how-to">Guides</h2>
+<h2 id="guides">Guides</h2>
 
 <ul>
   <li><a href="rdoc/files/doc/guides/admin_activation_rdoc.html">Require account verification by admin</a></li>


### PR DESCRIPTION
The original heading text was "How-To", which was then changed to "Guides". This updates the anchor identifier accordingly as well.
