### PR TITLE
Add route before hook for jwt-refresh

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -25,6 +25,8 @@ module Rodauth
     )
 
     route do |r|
+      before_jwt_refresh_route
+
       r.post do
         if (refresh_token = param_or_nil(jwt_refresh_token_key_param)) && account_from_refresh_token(refresh_token)
           formatted_token = nil


### PR DESCRIPTION
I noticed that the documentation describes the hook http://rodauth.jeremyevans.net/rdoc/files/doc/jwt_refresh_rdoc.html but it doesn't work and it looks like it's not written in the code