### PR TITLE
Add ability to use catch_error behavior into before and after hooks

### DIFF
--- a/lib/rodauth/features/close_account.rb
+++ b/lib/rodauth/features/close_account.rb
@@ -33,7 +33,11 @@ module Rodauth
       end
 
       r.post do
-        if !close_account_requires_password? || password_match?(param(password_param))
+        catch_error do
+          if close_account_requires_password? && !password_match?(param(password_param))
+            throw_error_status(invalid_password_error_status, password_param, invalid_password_message)
+          end
+
           transaction do
             before_close_account
             close_account
@@ -46,12 +50,10 @@ module Rodauth
 
           set_notice_flash close_account_notice_flash
           redirect close_account_redirect
-        else
-          set_response_error_status(invalid_password_error_status)
-          set_field_error(password_param, invalid_password_message)
-          set_error_flash close_account_error_flash
-          close_account_view
         end
+
+        set_error_flash close_account_error_flash
+        close_account_view
       end
     end
 


### PR DESCRIPTION
Many actions allow to use behavior of catch_error with hooks.
This makes it easy to return your errors with throw_error_status.

```ruby
before_close_account do
  throw_error_status(field, filed_param, error_message) if some_code
end
```

I think it would be convenient to have the same opportunity in this action.

Are there any reasons not to use this approach everywhere?
I could contribute on the remaining actions.

Thanks, Alexey