### PR TITLE
Remove unnecessary variable assignment in jwt_refresh

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -29,7 +29,6 @@ module Rodauth
 
       r.post do
         if (refresh_token = param_or_nil(jwt_refresh_token_key_param)) && account_from_refresh_token(refresh_token)
-          formatted_token = nil
           transaction do
             before_refresh_token
             formatted_token = generate_refresh_token


### PR DESCRIPTION
This isn't needed anymore after https://github.com/jeremyevans/rodauth/commit/4c52564817bea2a982aa8fb7276925a9d345d66f.
