### PR TITLE
Rename #_login to #login and make it public

### DIFF
--- a/doc/login.rdoc
+++ b/doc/login.rdoc
@@ -3,6 +3,13 @@
 The login feature implements a login page.  It's the most commonly
 used feature.
 
+In addition to the auth methods below, it provides a +login+ method that wraps
++login_session+, running login hooks and redirecting to the configured
+location.
+
+  rodauth.account           #=> { id: 123, ... }
+  rodauth.login('password') # login the current account
+
 == Auth Value Methods
 
 login_additional_form_tags :: HTML fragment containing additional form tags to use on the login form.

--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -94,7 +94,7 @@ module Rodauth
           redirect email_auth_email_sent_redirect
         end
 
-        _login('email_auth')
+        login('email_auth')
       end
     end
 

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -62,7 +62,7 @@ module Rodauth
             throw_error_status(login_error_status, password_param, invalid_password_message)
           end
 
-          _login('password')
+          login('password')
         end
 
         set_error_flash login_error_flash unless skip_error_flash
@@ -71,6 +71,18 @@ module Rodauth
     end
 
     attr_reader :login_form_header
+
+    def login(auth_type)
+      saved_login_redirect = remove_session_value(login_redirect_session_key)
+      transaction do
+        before_login
+        login_session(auth_type)
+        yield if block_given?
+        after_login
+      end
+      set_notice_flash login_notice_flash
+      redirect(saved_login_redirect || login_redirect)
+    end
 
     def login_required
       if login_return_to_requested_location?
@@ -126,15 +138,8 @@ module Rodauth
     end
 
     def _login(auth_type)
-      saved_login_redirect = remove_session_value(login_redirect_session_key)
-      transaction do
-        before_login
-        login_session(auth_type)
-        yield if block_given?
-        after_login
-      end
-      set_notice_flash login_notice_flash
-      redirect(saved_login_redirect || login_redirect)
+      warn("Deprecated #_login method called, use #login instead.")
+      login(auth_type)
     end
   end
 end

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -22,7 +22,7 @@ module Rodauth
 
           webauthn_credential = webauthn_auth_credential_from_form_submission
           before_webauthn_login
-          _login('webauthn') do
+          login('webauthn') do
             webauthn_update_session(webauthn_credential.id)
           end
         end


### PR DESCRIPTION
A `#login` method is useful when having custom authentication logic, such as using OmniAuth to allow people to authenticate through 3rd-party services, for example:

```rb
r.get "/auth/callback" do
  auth  = request.env["omniauth.auth"]
  email = auth["info"]["email"]

  rodauth.account_from_login(email)
  rodauth.login('omniauth')
end
```

Here the user is not logging in via email/password, but we still want to reuse things like login hooks, notice flash and redirect logic.

I would like to create an OmniAuth integration at some point, which would be able to use Rodauth's private `#_login` method, but I would still like the rely on the method being here to stay.