### PR TITLE
Simplify multi-phase login logic

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -517,6 +517,11 @@ module Rodauth
       catch(:rodauth_error, &block)
     end
 
+    def halt(body)
+      response.write body
+      request.halt
+    end
+
     # Don't set an error status when redirecting in an error case, as a redirect status is needed.
     def set_redirect_error_status(status)
     end

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -273,8 +273,7 @@ module Rodauth
     def show_lockout_page
       set_response_error_status lockout_error_status
       set_error_flash login_lockout_error_flash
-      response.write unlock_account_request_view
-      request.halt
+      halt unlock_account_request_view
     end
 
     def create_unlock_account_email

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -32,9 +32,6 @@ module Rodauth
       end
 
       r.post do
-        skip_error_flash = false
-        view = :login_view
-
         catch_error do
           unless account_from_login(param(login_param))
             throw_error_status(no_matching_login_error_status, login_param, no_matching_login_message)
@@ -48,12 +45,10 @@ module Rodauth
 
           if use_multi_phase_login?
             @valid_login_entered = true
-            view = :multi_phase_login_view
 
             unless param_or_nil(password_param)
               after_login_entered_during_multi_phase_login
-              skip_error_flash = true
-              next
+              halt multi_phase_login_view
             end
           end
 
@@ -65,8 +60,8 @@ module Rodauth
           login('password')
         end
 
-        set_error_flash login_error_flash unless skip_error_flash
-        send(view)
+        set_error_flash login_error_flash
+        login_view
       end
     end
 

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -194,8 +194,7 @@ module Rodauth
       if account_from_login(login) && allow_resending_verify_account_email?
         set_redirect_error_status(unopen_account_error_status)
         set_error_flash attempt_to_create_unverified_account_error_flash
-        response.write resend_verify_account_view
-        request.halt
+        halt resend_verify_account_view
       end
       super
     end
@@ -265,8 +264,7 @@ module Rodauth
       unless open_account?
         set_redirect_error_status(unopen_account_error_status)
         set_error_flash attempt_to_login_to_unverified_account_error_flash
-        response.write resend_verify_account_view
-        request.halt
+        halt resend_verify_account_view
       end
       super
     end


### PR DESCRIPTION
I came up with a way to simplify the multi-phase login code in the login endpoint. I like that now only the `using_multi_phase_login?` branch is concerned with multi-phase login logic, the rest of the code is handling regular login.

I've also extracted the `#halt` method in the process, which I found useful in other places as well.
