### PR TITLE
Add support for Postgres UUID primary keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
       dist: trusty
     - rvm: jruby-9.1.17.0
       dist: trusty
+    - rvm: 2.7
+      dist: trusty
+      env: RODAUTH_SPEC_UUID=true
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -94,6 +94,7 @@ task :db_setup_postgres do
   sh 'psql -U postgres -c "CREATE USER rodauth_test_password PASSWORD \'rodauth_test\'"'
   sh 'createdb -U postgres -O rodauth_test rodauth_test'
   sh 'psql -U postgres -c "CREATE EXTENSION citext" rodauth_test'
+  sh 'psql -U postgres -c "CREATE EXTENSION pgcrypto" rodauth_test'
   $: << 'lib'
   require 'sequel'
   Sequel.extension :migration
@@ -164,6 +165,7 @@ task :spec_travis do
     my_db = "mysql2://localhost/rodauth_test?user=root"
   end
   sh 'psql -U postgres -c "CREATE EXTENSION citext" rodauth_test'
+  sh 'psql -U postgres -c "CREATE EXTENSION pgcrypto" rodauth_test'
   spec.call('RODAUTH_SPEC_MIGRATE'=>'1', 'RODAUTH_SPEC_DB'=>pg_db)
   spec.call('RODAUTH_SPEC_MIGRATE'=>'1', 'RODAUTH_SPEC_DB'=>my_db)
 end

--- a/spec/close_account_spec.rb
+++ b/spec/close_account_spec.rb
@@ -138,7 +138,7 @@ describe 'Rodauth close_account feature' do
     click_button 'Close Account'
     page.current_path.must_equal '/'
 
-    DB[:accounts].reverse(:id).get(:status_id).must_equal 3
+    DB[:accounts].where(:email=>'foo2@example.com').get(:status_id).must_equal 3
   end
 
   it "should support closing accounts via jwt" do

--- a/spec/create_account_spec.rb
+++ b/spec/create_account_spec.rb
@@ -120,7 +120,7 @@ describe 'Rodauth create_account feature' do
     res.must_equal [422, {'error'=>"There was an error creating your account", "field-error"=>["password", "passwords do not match"]}]
 
     res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
-    res.must_equal [200, {'success'=>"Your account has been created", 'account_id'=>DB[:accounts].max(:id)}]
+    res.must_equal [200, {'success'=>"Your account has been created", 'account_id'=>DB[:accounts].where(:email=>'foo@example2.com').get(:id)}]
 
     json_login(:login=>'foo@example2.com')
   end

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -145,7 +145,7 @@ describe 'Rodauth login feature' do
     res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
     refresh_token = res.last.delete('refresh_token')
     @authorization = res.last.delete('access_token')
-    res.must_equal [200, {'success'=>"Your account has been created", 'account_id'=>DB[:accounts].max(:id)}]
+    res.must_equal [200, {'success'=>"Your account has been created", 'account_id'=>DB[:accounts].where(:email=>'foo@example2.com').get(:id)}]
 
     res = json_request("/")
     res.must_equal [200, {'hello'=>'world'}]

--- a/spec/migrate/001_tables.rb
+++ b/spec/migrate/001_tables.rb
@@ -1,10 +1,6 @@
 Sequel.migration do
   up do
-    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
-                         :uuid
-                       else
-                         :bigint
-                       end
+    primary_key_type = ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres ? :uuid : :bigint
 
     extension :date_arithmetic
 

--- a/spec/migrate/001_tables.rb
+++ b/spec/migrate/001_tables.rb
@@ -1,5 +1,11 @@
 Sequel.migration do
   up do
+    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
+                         :uuid
+                       else
+                         :bigint
+                       end
+
     extension :date_arithmetic
 
     # Used by the account verification and close account features
@@ -11,7 +17,11 @@ Sequel.migration do
 
     db = self
     create_table(:accounts) do
-      primary_key :id, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
       foreign_key :status_id, :account_statuses, :null=>false, :default=>1
       if db.database_type == :postgres
         citext :email, :null=>false
@@ -41,8 +51,12 @@ Sequel.migration do
       String
     end
     create_table(:account_authentication_audit_logs) do
-      primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
+      foreign_key :account_id, :accounts, :null=>false, :type=>primary_key_type
       DateTime :at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       String :message, :null=>false
       column :metadata, json_type
@@ -52,7 +66,7 @@ Sequel.migration do
 
     # Used by the password reset feature
     create_table(:account_password_reset_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -60,8 +74,12 @@ Sequel.migration do
 
     # Used by the jwt refresh feature
     create_table(:account_jwt_refresh_keys) do
-      primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
+      foreign_key :account_id, :accounts, :null=>false, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       index :account_id, :name=>:account_jwt_rk_account_id_idx
@@ -69,7 +87,7 @@ Sequel.migration do
 
     # Used by the account verification feature
     create_table(:account_verification_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :requested_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -77,7 +95,7 @@ Sequel.migration do
 
     # Used by the verify login change feature
     create_table(:account_login_change_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       String :login, :null=>false
       DateTime :deadline, deadline_opts[1]
@@ -85,18 +103,18 @@ Sequel.migration do
 
     # Used by the remember me feature
     create_table(:account_remember_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[14]
     end
 
     # Used by the lockout feature
     create_table(:account_login_failures) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       Integer :number, :null=>false, :default=>1
     end
     create_table(:account_lockouts) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent
@@ -104,7 +122,7 @@ Sequel.migration do
 
     # Used by the email auth feature
     create_table(:account_email_auth_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -112,13 +130,13 @@ Sequel.migration do
 
     # Used by the password expiration feature
     create_table(:account_password_change_times) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       DateTime :changed_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     # Used by the account expiration feature
     create_table(:account_activity_times) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       DateTime :last_activity_at, :null=>false
       DateTime :last_login_at, :null=>false
       DateTime :expired_at
@@ -126,13 +144,13 @@ Sequel.migration do
 
     # Used by the single session feature
     create_table(:account_session_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
     end
 
     # Used by the active sessions feature
     create_table(:account_active_session_keys) do
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :session_id
       Time :created_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -141,11 +159,11 @@ Sequel.migration do
 
     # Used by the webauthn feature
     create_table(:account_webauthn_user_ids) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :webauthn_id, :null=>false
     end
     create_table(:account_webauthn_keys) do
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :webauthn_id
       String :public_key, :null=>false
       Integer :sign_count, :null=>false
@@ -155,7 +173,7 @@ Sequel.migration do
 
     # Used by the otp feature
     create_table(:account_otp_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       Integer :num_failures, :null=>false, :default=>0
       Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -163,14 +181,14 @@ Sequel.migration do
 
     # Used by the recovery codes feature
     create_table(:account_recovery_codes) do
-      foreign_key :id, :accounts, :type=>:Bignum
+      foreign_key :id, :accounts, :type=>primary_key_type
       String :code
       primary_key [:id, :code]
     end
 
     # Used by the sms codes feature
     create_table(:account_sms_codes) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :phone_number, :null=>false
       Integer :num_failures
       String :code

--- a/spec/migrate_password/001_tables.rb
+++ b/spec/migrate_password/001_tables.rb
@@ -49,7 +49,7 @@ Sequel.migration do
       run "REVOKE ALL ON FUNCTION rodauth_previous_password_hash_match(int8, text) FROM public"
       run "GRANT INSERT, UPDATE, DELETE ON account_previous_password_hashes TO #{user}"
       run "GRANT SELECT(id, account_id) ON account_previous_password_hashes TO #{user}"
-      # run "GRANT USAGE ON account_previous_password_hashes_id_seq TO #{user}"
+      run "GRANT USAGE ON account_previous_password_hashes_id_seq TO #{user}"
       run "GRANT EXECUTE ON FUNCTION rodauth_get_previous_salt(int8) TO #{user}"
       run "GRANT EXECUTE ON FUNCTION rodauth_previous_password_hash_match(int8, text) TO #{user}"
     when :mysql

--- a/spec/migrate_password/001_tables.rb
+++ b/spec/migrate_password/001_tables.rb
@@ -2,8 +2,14 @@ require 'rodauth/migrations'
 
 Sequel.migration do
   up do
+    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
+                         :uuid
+                       else
+                         :bigint
+                       end
+
     create_table(:account_password_hashes) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :password_hash, :null=>false
     end
     Rodauth.create_database_authentication_functions(self)
@@ -11,12 +17,12 @@ Sequel.migration do
     when :postgres
       user = get(Sequel.lit('current_user')).sub(/_password\z/, '')
       run "REVOKE ALL ON account_password_hashes FROM public"
-      run "REVOKE ALL ON FUNCTION rodauth_get_salt(int8) FROM public"
-      run "REVOKE ALL ON FUNCTION rodauth_valid_password_hash(int8, text) FROM public"
+      run "REVOKE ALL ON FUNCTION rodauth_get_salt(#{primary_key_type}) FROM public"
+      run "REVOKE ALL ON FUNCTION rodauth_valid_password_hash(#{primary_key_type}, text) FROM public"
       run "GRANT INSERT, UPDATE, DELETE ON account_password_hashes TO #{user}"
       run "GRANT SELECT(id) ON account_password_hashes TO #{user}"
-      run "GRANT EXECUTE ON FUNCTION rodauth_get_salt(int8) TO #{user}"
-      run "GRANT EXECUTE ON FUNCTION rodauth_valid_password_hash(int8, text) TO #{user}"
+      run "GRANT EXECUTE ON FUNCTION rodauth_get_salt(#{primary_key_type}) TO #{user}"
+      run "GRANT EXECUTE ON FUNCTION rodauth_valid_password_hash(#{primary_key_type}, text) TO #{user}"
     when :mysql
       user = get(Sequel.lit('current_user')).sub(/_password@/, '@')
       db_name = get(Sequel.function(:database))
@@ -34,7 +40,7 @@ Sequel.migration do
     # Used by the disallow_password_reuse feature
     create_table(:account_previous_password_hashes) do
       primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :password_hash, :null=>false
     end
     Rodauth.create_database_previous_password_check_functions(self)
@@ -47,7 +53,7 @@ Sequel.migration do
       run "REVOKE ALL ON FUNCTION rodauth_previous_password_hash_match(int8, text) FROM public"
       run "GRANT INSERT, UPDATE, DELETE ON account_previous_password_hashes TO #{user}"
       run "GRANT SELECT(id, account_id) ON account_previous_password_hashes TO #{user}"
-      run "GRANT USAGE ON account_previous_password_hashes_id_seq TO #{user}"
+      # run "GRANT USAGE ON account_previous_password_hashes_id_seq TO #{user}"
       run "GRANT EXECUTE ON FUNCTION rodauth_get_previous_salt(int8) TO #{user}"
       run "GRANT EXECUTE ON FUNCTION rodauth_previous_password_hash_match(int8, text) TO #{user}"
     when :mysql

--- a/spec/migrate_password/001_tables.rb
+++ b/spec/migrate_password/001_tables.rb
@@ -2,11 +2,7 @@ require 'rodauth/migrations'
 
 Sequel.migration do
   up do
-    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
-                         :uuid
-                       else
-                         :bigint
-                       end
+    primary_key_type = ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres ? :uuid : :bigint
 
     create_table(:account_password_hashes) do
       foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type

--- a/spec/migrate_travis/001_tables.rb
+++ b/spec/migrate_travis/001_tables.rb
@@ -2,6 +2,12 @@ require 'rodauth/migrations'
 
 Sequel.migration do
   up do
+    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
+                         :uuid
+                       else
+                         :Bignum
+                       end
+
     extension :date_arithmetic
 
     create_table(:account_statuses) do
@@ -12,7 +18,11 @@ Sequel.migration do
 
     db = self
     create_table(:accounts) do
-      primary_key :id, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
       foreign_key :status_id, :account_statuses, :null=>false, :default=>1
       if db.database_type == :postgres
         citext :email, :null=>false
@@ -27,7 +37,7 @@ Sequel.migration do
     end
 
     create_table(:account_password_hashes) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :password_hash, :null=>false
     end
     Rodauth.create_database_authentication_functions(self)
@@ -49,8 +59,12 @@ Sequel.migration do
       String
     end
     create_table(:account_authentication_audit_logs) do
-      primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
+      foreign_key :account_id, :accounts, :null=>false, :type=>primary_key_type
       DateTime :at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       String :message, :null=>false
       column :metadata, json_type
@@ -59,77 +73,81 @@ Sequel.migration do
     end
 
     create_table(:account_password_reset_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     create_table(:account_jwt_refresh_keys) do
-      primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
+      if primary_key_type == :uuid
+        uuid :id, :primary_key=>true, :default=>Sequel.function(:gen_random_uuid)
+      else
+        primary_key :id, :type=>:Bignum
+      end
+      foreign_key :account_id, :accounts, :null=>false, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       index :account_id, :name=>:account_jwt_rk_account_id_idx
     end
 
     create_table(:account_verification_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :requested_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     create_table(:account_login_change_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       String :login, :null=>false
       DateTime :deadline, deadline_opts[1]
     end
 
     create_table(:account_remember_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[14]
     end
 
     create_table(:account_email_auth_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     create_table(:account_login_failures) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       Integer :number, :null=>false, :default=>1
     end
     create_table(:account_lockouts) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       DateTime :deadline, deadline_opts[1]
       DateTime :email_last_sent
     end
 
     create_table(:account_password_change_times) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       DateTime :changed_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     create_table(:account_activity_times) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       DateTime :last_activity_at, :null=>false
       DateTime :last_login_at, :null=>false
       DateTime :expired_at
     end
 
     create_table(:account_session_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
     end
 
     create_table(:account_active_session_keys) do
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :session_id
       Time :created_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
       Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
@@ -137,11 +155,11 @@ Sequel.migration do
     end
 
     create_table(:account_webauthn_user_ids) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :webauthn_id, :null=>false
     end
     create_table(:account_webauthn_keys) do
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :webauthn_id
       String :public_key, :null=>false
       Integer :sign_count, :null=>false
@@ -150,20 +168,20 @@ Sequel.migration do
     end
 
     create_table(:account_otp_keys) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :key, :null=>false
       Integer :num_failures, :null=>false, :default=>0
       Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
     end
 
     create_table(:account_recovery_codes) do
-      foreign_key :id, :accounts, :type=>:Bignum
+      foreign_key :id, :accounts, :type=>primary_key_type
       String :code
       primary_key [:id, :code]
     end
 
     create_table(:account_sms_codes) do
-      foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
+      foreign_key :id, :accounts, :primary_key=>true, :type=>primary_key_type
       String :phone_number, :null=>false
       Integer :num_failures
       String :code
@@ -172,7 +190,7 @@ Sequel.migration do
 
     create_table(:account_previous_password_hashes) do
       primary_key :id, :type=>:Bignum
-      foreign_key :account_id, :accounts, :type=>:Bignum
+      foreign_key :account_id, :accounts, :type=>primary_key_type
       String :password_hash, :null=>false
     end
     Rodauth.create_database_previous_password_check_functions(self)

--- a/spec/migrate_travis/001_tables.rb
+++ b/spec/migrate_travis/001_tables.rb
@@ -2,11 +2,7 @@ require 'rodauth/migrations'
 
 Sequel.migration do
   up do
-    primary_key_type = if ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres
-                         :uuid
-                       else
-                         :Bignum
-                       end
+    primary_key_type = ENV['RODAUTH_SPEC_UUID'] && database_type == :postgres ? :uuid : :bigint
 
     extension :date_arithmetic
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -355,7 +355,7 @@ describe 'Rodauth' do
     self.app = app
 
     login(:path=>'/r1/login')
-    page.body.must_equal DB[:accounts].get(:id).to_s
+    page.body.must_equal DB[:accounts].get(:id).inspect
 
     visit '/r2/logout'
     click_button 'Logout'


### PR DESCRIPTION
@janko and I have been working on adding Postgres UUID support to Rodauth.

This patch implements the needed changes to support UUIDs as primary and foreign keys where appropriate.
The user implementing Rodauth in their system has to use UUIDs as primary keys when creating their tables or tables that rodauth internally uses. A full example is available in `spec/migrate/001_tables.rb`.

Comments:
* The `account_previous_password_hashes` uses a Bignum as the primary key as the row ID is never referenced except for sorting. UUID could be used here, but it would require the introduction of a new column to make the sort stable, and existing systems using Rodauth would require a migration task.
* The `account_statuses` uses Bignum as the primary key as the number of elements is expected to be low and it has to be predictable
* The audit log tests now search for an entry with the message they expect as sorting based on timestamps (that is the `CURRENT_TIMESTAMP` and `NOW` functions) returns the time the transaction initiated, and therefore all rows created within the test (as they share the same transaction) are created with an identical timestamp.
* Some lines ending with `to_s` in the test suite have been changed to end with `inspect` as to differentiate results containing UUIDs form results containing numbers (`'foo'.to_s # => "foo"` while `'foo'.inspect # => "\"foo\""`).
* We have added a new entry in the Travis matrix to test UUID support
* At some places we read a table's primary key type so that the user doesn't have to specify the type of primary key they use.


Co-authored-by: Janko Marohnić <janko.marohnic@gmail.com>