### PR TITLE
Add ability to assign a public key

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -27,6 +27,7 @@ module Rodauth
     auth_value_methods(
       :only_json?,
       :jwt_secret,
+      :jwt_public_secret,
       :use_jwt?
     )
 
@@ -229,9 +230,13 @@ module Rodauth
       end
     end
 
+    def jwt_public_secret
+      jwt_secret
+    end
+
     def jwt_payload
       return @jwt_payload if defined?(@jwt_payload)
-      @jwt_payload = JWT.decode(jwt_token, jwt_secret, true, jwt_decode_opts.merge(:algorithm=>jwt_algorithm))[0]
+      @jwt_payload = JWT.decode(jwt_token, jwt_public_secret, true, jwt_decode_opts.merge(:algorithm=>jwt_algorithm))[0]
     rescue JWT::DecodeError
       @jwt_payload = false
     end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -121,6 +121,24 @@ describe 'Rodauth login feature' do
     res.must_equal true
   end
 
+  it "should use RS256 algorithm fot jwt token" do
+    rsa_private = OpenSSL::PKey::RSA.generate 512
+    rsa_public = rsa_private.public_key
+
+    rodauth do
+      enable :login, :jwt
+      jwt_algorithm "RS256"
+      jwt_secret rsa_private
+      jwt_public_secret rsa_public
+    end
+    roda(:jwt_html) do |r|
+      r.rodauth
+    end
+
+    res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
+    res.must_equal true
+  end
+
   it "should require POST for json requests" do
     rodauth do
       enable :login, :logout, :jwt


### PR DESCRIPTION
Currently, there is no way to use the `RSA` algorithm due to the fact that different keys cannot be assigned for encoding and decoding.