### PR TITLE
Add password_pepper feature

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,6 +44,7 @@ HTML and JSON API for all supported features.
 * Verify Account Grace Period (Don't require verification before login)
 * Password Grace Period (Don't require password entry if recently entered)
 * Password Complexity (More sophisticated checks)
+* Password Pepper
 * Disallow Password Reuse
 * Disallow Common Passwords
 * Password Expiration
@@ -881,6 +882,7 @@ view the appropriate file in the doc directory.
 * {Password Complexity}[rdoc-ref:doc/password_complexity.rdoc]
 * {Password Expiration}[rdoc-ref:doc/password_expiration.rdoc]
 * {Password Grace Period}[rdoc-ref:doc/password_grace_period.rdoc]
+* {Password Pepper}[rdoc-ref:doc/password_pepper.rdoc]
 * {Recovery Codes}[rdoc-ref:doc/recovery_codes.rdoc]
 * {Remember}[rdoc-ref:doc/remember.rdoc]
 * {Reset Password}[rdoc-ref:doc/reset_password.rdoc]

--- a/doc/password_pepper.rdoc
+++ b/doc/password_pepper.rdoc
@@ -1,0 +1,32 @@
+= Documentation for Password Pepper Feature
+
+The password pepper feature appends a specified secret string to passwords
+before they are hashed. This way, if the password hashes get compromised, an
+attacker cannot use them to crack the passwords without also knowing the
+pepper.
+
+In the configuration block set the +password_pepper+ with your secret string.
+It's recommended for the password pepper to be at last 32 characters long and
+randomly generated.
+
+  password_pepper "<long secret key>"
+
+If your database already contains password hashes that were created without a
+password pepper, these will get automatically updated with a password pepper
+next time the user successfully enters their password.
+
+You can rotate the password pepper as well, just make sure to add the previous
+pepper to the +previous_password_peppers+ array. Password hashes using the old
+pepper will get automatically updated on the next successful password match.
+
+  password_pepper "new pepper"
+  previous_password_peppers ["old pepper", ""] 
+
+The empty string above ensures password hashes without pepper are handled as
+well.
+
+== Auth Value Methods
+
+password_pepper :: The secret string appended to passwords before they are hashed.
+previous_password_peppers :: An array of password peppers that will be tried on an unsuccessful password match. Defaults to +[""]+.
+password_pepper_update? :: Whether to update password hashes that use a pepper from +previous_password_peppers+ with a new pepper. Defaults to +true+.

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -393,9 +393,9 @@ module Rodauth
     def password_match?(password)
       if hash = get_password_hash
         if account_password_hash_column || !use_database_authentication_functions?
-          BCrypt::Password.new(hash) == password
+          password_hash_match?(hash, password)
         else
-          db.get(Sequel.function(function_name(:rodauth_valid_password_hash), account_id, BCrypt::Engine.hash_secret(password, hash)))
+          database_function_password_match?(:rodauth_valid_password_hash, account_id, password, hash)
         end 
       end
     end
@@ -457,6 +457,14 @@ module Rodauth
     end
 
     private
+
+    def database_function_password_match?(name, hash_id, password, salt)
+      db.get(Sequel.function(function_name(name), hash_id, BCrypt::Engine.hash_secret(password, salt)))
+    end
+
+    def password_hash_match?(hash, password)
+      BCrypt::Password.new(hash) == password
+    end
 
     def convert_token_key(key)
       if key && hmac_secret

--- a/lib/rodauth/features/disallow_password_reuse.rb
+++ b/lib/rodauth/features/disallow_password_reuse.rb
@@ -51,11 +51,13 @@ module Rodauth
         return true if salts.empty?
 
         salts.any? do |hash_id, salt|
-          db.get(Sequel.function(function_name(:rodauth_previous_password_hash_match), hash_id, BCrypt::Engine.hash_secret(password, salt)))
+          database_function_password_match?(:rodauth_previous_password_hash_match, hash_id, password, salt)
         end
       else
         # :nocov:
-        previous_password_ds.select_map(previous_password_hash_column).any?{|hash| BCrypt::Password.new(hash) == password}
+        previous_password_ds.select_map(previous_password_hash_column).any? do |hash|
+          password_hash_match?(hash, password)
+        end
         # :nocov:
       end
 

--- a/lib/rodauth/features/password_pepper.rb
+++ b/lib/rodauth/features/password_pepper.rb
@@ -1,0 +1,45 @@
+# frozen-string-literal: true
+
+module Rodauth
+  Feature.define(:password_pepper, :PasswordPepper) do
+    depends :login_password_requirements_base
+
+    auth_value_method :password_pepper, nil
+    auth_value_method :previous_password_peppers, [""]
+    auth_value_method :password_pepper_update?, true
+
+    def password_match?(password)
+      if (result = super) && @previous_pepper_matched && password_pepper_update?
+        set_password(password)
+      end
+
+      result
+    end
+
+    private
+
+    def password_hash(password)
+      super(password + password_pepper.to_s)
+    end
+
+    def password_hash_match?(hash, password)
+      return super if password_pepper.nil?
+
+      return true if super(hash, password + password_pepper)
+
+      @previous_pepper_matched = previous_password_peppers.any? do |pepper|
+        super(hash, password + pepper)
+      end
+    end
+
+    def database_function_password_match?(name, hash_id, password, salt)
+      return super if password_pepper.nil?
+
+      return true if super(name, hash_id, password + password_pepper, salt)
+
+      @previous_pepper_matched = previous_password_peppers.any? do |pepper|
+        super(name, hash_id, password + pepper, salt)
+      end
+    end
+  end
+end

--- a/spec/password_pepper_spec.rb
+++ b/spec/password_pepper_spec.rb
@@ -1,0 +1,256 @@
+require_relative 'spec_helper'
+
+describe 'Rodauth password_pepper feature' do
+  [true, false].each do |ph|
+    it "should use password pepper on login when account_password_hash_column is #{ph}" do
+      pepper = "secret"
+      previous_peppers = [""]
+      rodauth do
+        enable :login, :logout, :password_pepper
+        password_pepper { pepper }
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      login
+      page.html.must_include "Logged In"
+
+      pepper = nil
+      logout
+      login
+      page.find("#error_flash").text.must_equal "There was an error logging in"
+    end
+
+    it "should support rotating password pepper when account_password_hash_column is #{ph}" do
+      pepper = "secret"
+      previous_peppers = [""]
+      rodauth do
+        enable :login, :logout, :password_pepper
+        password_pepper { pepper }
+        previous_password_peppers { previous_peppers }
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      login
+      page.html.must_include "Logged In"
+
+      previous_peppers = []
+      logout
+      login
+      page.html.must_include "Logged In"
+
+      previous_peppers = [pepper]
+      pepper = "new secret"
+      logout
+      login
+      page.html.must_include "Logged In"
+
+      previous_peppers = []
+      logout
+      login
+      page.html.must_include "Logged In"
+
+      pepper = "new new secret"
+      logout
+      login
+      page.find("#error_flash").text.must_equal "There was an error logging in"
+    end
+
+    it "should support not updating old peppers when account_password_hash_column is #{ph}" do
+      pepper = "secret"
+      previous_peppers = [""]
+      rodauth do
+        enable :change_password, :login, :logout, :password_pepper
+        password_pepper { pepper }
+        previous_password_peppers { previous_peppers }
+        password_pepper_update? false
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      login
+      page.html.must_include "Logged In"
+
+      previous_peppers = []
+      logout
+      login
+      page.find("#error_flash").text.must_equal "There was an error logging in"
+    end
+
+    it "should use password pepper when changing password when account_password_hash_column is #{ph}" do
+      pepper = nil
+      rodauth do
+        enable :login, :logout, :password_pepper, :change_password
+        password_pepper { pepper }
+        previous_password_peppers []
+        change_password_requires_password? false
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      login
+      page.html.must_include "Logged In"
+
+      pepper = "secret"
+      visit "/change-password"
+      fill_in "New Password", with: "new password"
+      fill_in "Confirm Password", with: "new password"
+      click_on "Change Password"
+      page.find("#notice_flash").text.must_equal "Your password has been changed"
+
+      logout
+      login(pass: "new password")
+      page.html.must_include "Logged In"
+
+      pepper = nil
+      logout
+      login(pass: "new password")
+      page.find("#error_flash").text.must_equal "There was an error logging in"
+    end
+
+    it "should use password pepper when resetting password when account_password_hash_column is #{ph}" do
+      pepper = "secret"
+      rodauth do
+        enable :login, :logout, :password_pepper, :reset_password
+        password_pepper { pepper }
+        previous_password_peppers []
+        reset_password_email_sent_redirect "/login"
+        reset_password_redirect "/login"
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      visit "/reset-password-request"
+      fill_in "Login", with: "foo@example.com"
+      click_on "Request Password Reset"
+      page.find("#notice_flash").text.must_equal "An email has been sent to you with a link to reset the password for your account"
+
+      visit email_link(/(\/reset-password\?key=.+)$/)
+      fill_in "Password", with: "new password"
+      fill_in "Confirm Password", with: "new password"
+      click_on "Reset Password"
+      page.find("#notice_flash").text.must_equal "Your password has been reset"
+
+      login(pass: "new password")
+      page.html.must_include "Logged In"
+
+      pepper = nil
+      logout
+      login(pass: "new password")
+      page.find("#error_flash").text.must_equal "There was an error logging in"
+    end
+
+    it "should work without setting password pepper when account_password_hash_column is #{ph}" do
+      rodauth do
+        enable :login, :logout, :password_pepper, :change_password
+        change_password_requires_password? false
+        account_password_hash_column :ph if ph
+      end
+      roda do |r|
+        r.rodauth
+        next unless rodauth.logged_in?
+        r.root{view :content=>"Logged In"}
+      end
+
+      login
+      page.html.must_include "Logged In"
+
+      visit '/change-password'
+      fill_in 'New Password', :with=>"new password"
+      fill_in 'Confirm Password', :with=>"new password"
+      click_on 'Change Password'
+      page.find('#notice_flash').text.must_equal "Your password has been changed"
+
+      logout
+      login(pass: "new password")
+      page.html.must_include "Logged In"
+    end
+  end
+
+  it "should work with disallow_password_reuse feature" do
+    pepper = nil
+    previous_peppers = [""]
+    rodauth do
+      enable :login, :logout, :change_password, :disallow_password_reuse, :password_pepper
+      password_pepper { pepper }
+      previous_password_peppers { previous_peppers }
+      change_password_requires_password? false
+    end
+    roda do |r|
+      r.rodauth
+      next unless rodauth.logged_in?
+      r.root{view :content=>"Logged In"}
+    end
+
+    login
+    page.html.must_include "Logged In"
+
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_1"
+    fill_in 'Confirm Password', :with=>"password_1"
+    click_on 'Change Password'
+    page.find('#notice_flash').text.must_equal "Your password has been changed"
+
+    pepper = "secret_1"
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_2"
+    fill_in 'Confirm Password', :with=>"password_2"
+    click_on 'Change Password'
+    page.find('#notice_flash').text.must_equal "Your password has been changed"
+
+    previous_peppers.unshift pepper
+    pepper = "secret_2"
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_3"
+    fill_in 'Confirm Password', :with=>"password_3"
+    click_on 'Change Password'
+    page.find('#notice_flash').text.must_equal "Your password has been changed"
+
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_2"
+    fill_in 'Confirm Password', :with=>"password_2"
+    click_on 'Change Password'
+    page.find('#error_flash').text.must_equal "There was an error changing your password"
+
+    previous_peppers.shift
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_2"
+    fill_in 'Confirm Password', :with=>"password_2"
+    click_on 'Change Password'
+    page.find('#notice_flash').text.must_equal "Your password has been changed"
+
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_1"
+    fill_in 'Confirm Password', :with=>"password_1"
+    click_on 'Change Password'
+    page.find('#error_flash').text.must_equal "There was an error changing your password"
+
+    previous_peppers.shift
+    visit '/change-password'
+    fill_in 'New Password', :with=>"password_1"
+    fill_in 'Confirm Password', :with=>"password_1"
+    click_on 'Change Password'
+    page.find('#notice_flash').text.must_equal "Your password has been changed"
+  end
+end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -36,6 +36,7 @@
   <li><a href="rdoc/files/doc/password_complexity_rdoc.html">Password Complexity</a>: Adds more sophisticated complexity checks for passwords.</li>
   <li><a href="rdoc/files/doc/password_expiration_rdoc.html">Password Expiration</a>: Requires that accounts change their password after a given amount of time.</li>
   <li><a href="rdoc/files/doc/password_grace_period_rdoc.html">Password Grace Period</a>: Allows skipping password entry on forms normally requiring it if a user recently entered their password.</li>
+  <li><a href="rdoc/files/doc/password_pepper_rdoc.html">Password Pepper</a>: Allows appending a secret key to passwords before they are hashed.</li>
   <li><a href="rdoc/files/doc/recovery_codes_rdoc.html">Recovery Codes</a>: Adds support for mulitfactor authentication via single-use account recovery codes.</li>
   <li><a href="rdoc/files/doc/remember_rdoc.html">Remember</a>: Automatically logs a user in based on a token stored in a cookie.</li>
   <li><a href="rdoc/files/doc/reset_password_rdoc.html">Reset Password</a>: Allows users to reset their password if they don't remember it.</li>


### PR DESCRIPTION
A password [pepper] is a secret key that's appended to the password before it's hashed. This means that, in case an attacker was able to obtain password hashes from the database, they're not able to use them to crack the passwords without also knowing the password pepper.

Password peppering is supported by Devise and Sorcery, so I thought it would be nice for Rodauth to support it too. When using Rodauth's database functions, it's already difficult for an attacker to obtain password hashes, so password peppering is mostly intended for developers that have opted out of that, but it works with database functions as well.

```rb
enable :password_pepper
password_pepper "<long secret key>"
```

Pepper rotation is considered one of the difficulties when using peppers (neither Devise or Sorcery support it), so I baked that functionality right into the password_pepper feature. It works by storing old peppers into `previous_password_peppers`, in which case those peppers will be tried in addition to the current pepper when matching on a password. Password hashes using an old pepper will be also automatically updated to use the new one on successful password match (similar to how the update_password_hash feature works).

```rb
password_pepper "new pepper"
previous_password_peppers ["old pepper", ""]
```

The empty string above also handles passwords which don't use any peppers, which is necessary when introducing password peppers into an existing application. This case is also considered as pepper rotation, where the old pepper is an empty string. By making the empty string explicit, the developer can choose to opt-out in case they introduced password peppers from the very beginning.

I wanted password peppering to work with disallow_password_reuse feature as well, so I've extracted password hash matching (both in Ruby and via a database function) into separate methods. A nice upside of this is that now all BCrypt-specific code is contained in single-purpose methods, making it easier for the developer to switch to using another password hashing algorithm, such as scrypt or argon2.

[pepper]: https://en.wikipedia.org/wiki/Pepper_(cryptography)
