### PR TITLE
Add session_key_prefix configuration for adding prefix to all session keys

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1064,6 +1064,15 @@ the name as an argument to use that configuration:
     r.rodauth
   end
 
+By default, alternate configurations will use the same session keys as the
+primary configuration, which may be undesirable. To ensure session state is
+separated between configurations, you can set a session key prefix for
+alternate configurations:
+
+  plugin :rodauth, :name=>:secondary do
+    session_key_prefix "secondary_"
+  end
+
 === With Password Hashes Inside the Accounts Table
 
 You can use Rodauth if you are storing password hashes in the same

--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -17,6 +17,7 @@ mark_input_fields_as_required? :: Whether input fields should be marked as requi
 prefix :: The routing prefix used for Rodauth routes.  If you are calling in a routing subtree, this should be set to the root path of the subtree.  This should include a leading slash if set, but not a trailing slash.
 require_bcrypt? :: Set to false to not require bcrypt, useful if using custom authentication.
 session_key :: The key in the session hash storing the primary key of the logged in account.
+session_key_prefix :: The string that will be prepended to all session keys.
 skip_status_checks? :: Whether status checks should be skipped for accounts.  Defaults to true unless enabling the verify_account or close_account features.
 title_instance_variable :: The instance variable to set in the Roda scope with the page title.  The layout should use this instance variable if available to set the title of the page.  You can use +set_title+ if setting the page title is not done through an instance variable.
 

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -47,6 +47,7 @@ module Rodauth
     session_key :authenticated_by_session_key, :authenticated_by
     session_key :autologin_type_session_key, :autologin_type
     auth_value_method :prefix, ''
+    auth_value_method :session_key_prefix, nil
     auth_value_method :require_bcrypt?, true
     auth_value_method :mark_input_fields_as_required?, true
     auth_value_method :mark_input_fields_with_autocomplete?, true
@@ -501,6 +502,7 @@ module Rodauth
     end
 
     def convert_session_key(key)
+      key = "#{session_key_prefix}#{key}".to_sym if session_key_prefix
       scope.opts[:sessions_convert_symbols] ? key.to_s : key
     end
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -134,6 +134,23 @@ describe 'Rodauth' do
     page.text.must_equal 'http://www.example.com/auth/login?a[]=b&a[]=c'
   end
 
+  it "should support session key prefix" do
+    rodauth do
+      session_key_prefix "prefix_"
+    end
+    roda do |r|
+      r.root { rodauth.session_key.inspect }
+    end
+
+    visit '/'
+
+    if app.opts[:sessions_convert_symbols]
+      page.html.must_equal "\"prefix_account_id\""
+    else
+      page.html.must_equal ":prefix_account_id"
+    end
+  end
+
   it "should support translation" do
     rodauth do
       enable :login


### PR DESCRIPTION
In response to https://github.com/janko/rodauth-rails/issues/11, this PR adds the `session_key_prefix` configuration for prefixing all session keys. This is useful when using multiple Rodauth configurations, where it's usually desired to have the session state separated between configurations.

```rb
plugin :rodauth do
  # ...
end

plugin :rodauth, name: :admin do
  # ...
  session_key_prefix "admin_"
end
```

cc @bjeanes
