### PR TITLE
Set the redirect-after-login path as the fullpath only when it's a GET request

### DIFF
--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -86,7 +86,12 @@ module Rodauth
 
     def login_required
       if login_return_to_requested_location?
-        set_session_value(login_redirect_session_key, request.fullpath)
+        redirect_uri = if request.get?
+          request.fullpath
+        else
+          request.referer
+        end
+        set_session_value(login_redirect_session_key, redirect_uri) if redirect_uri
       end
       super
     end


### PR DESCRIPTION
Fixes #122 .

When setting the redirect url as the result of a POST submission, the `fullpath` might not render a page when issued in a GET request, which is what it's going to happen once the user logs in.

I've also added the request referer as the redirect url for non-GET requests, but this is still subject to revision.