### PR TITLE
Make `new_password_label` translatable

### DIFF
--- a/lib/rodauth/features/change_password.rb
+++ b/lib/rodauth/features/change_password.rb
@@ -14,7 +14,7 @@ module Rodauth
     button 'Change Password'
     redirect
 
-    auth_value_method :new_password_label, 'New Password'
+    translatable_method :new_password_label, 'New Password'
     auth_value_method :new_password_param, 'new-password'
 
     auth_value_methods(


### PR DESCRIPTION
I believe this has likely just been overlooked. I noticed it when the label wasn't changing when tweaking locale texts!