### PR TITLE
Allow translating `verify_login_change` notice flash

### DIFF
--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -29,6 +29,7 @@ module Rodauth
     auth_value_method :verify_login_change_login_column, :login
     session_key :verify_login_change_session_key, :verify_login_change_key
     auth_value_method :verify_login_change_table, :account_login_change_keys
+    translatable_method :verify_change_login_notice_flash, "An email has been sent to you with a link to verify your login change"
 
     auth_methods(
       :create_verify_login_change_email,
@@ -131,7 +132,7 @@ module Rodauth
     end
 
     def change_login_notice_flash
-      "An email has been sent to you with a link to verify your login change"
+      verify_change_login_notice_flash
     end
 
     def verify_login_change_old_login

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -29,7 +29,7 @@ module Rodauth
     auth_value_method :verify_login_change_login_column, :login
     session_key :verify_login_change_session_key, :verify_login_change_key
     auth_value_method :verify_login_change_table, :account_login_change_keys
-    translatable_method :verify_login_change_notice_flash, "An email has been sent to you with a link to verify your login change"
+    translatable_method :change_login_needs_verification_notice_flash, "An email has been sent to you with a link to verify your login change"
 
     auth_methods(
       :create_verify_login_change_email,
@@ -132,7 +132,7 @@ module Rodauth
     end
 
     def change_login_notice_flash
-      verify_login_change_notice_flash
+      change_login_needs_verification_notice_flash
     end
 
     def verify_login_change_old_login

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -29,7 +29,7 @@ module Rodauth
     auth_value_method :verify_login_change_login_column, :login
     session_key :verify_login_change_session_key, :verify_login_change_key
     auth_value_method :verify_login_change_table, :account_login_change_keys
-    translatable_method :verify_change_login_notice_flash, "An email has been sent to you with a link to verify your login change"
+    translatable_method :verify_login_change_notice_flash, "An email has been sent to you with a link to verify your login change"
 
     auth_methods(
       :create_verify_login_change_email,
@@ -132,7 +132,7 @@ module Rodauth
     end
 
     def change_login_notice_flash
-      verify_change_login_notice_flash
+      verify_login_change_notice_flash
     end
 
     def verify_login_change_old_login


### PR DESCRIPTION
I believe this should be backwards compatible but will allow users to override with translations the text which is displayed after changing login when the `verify_login_change` feature is enabled.

Importantly, this overrides the other key (as before) but via a different key which is override-able. This should preserve the ability to have distinct translations for each key in the case where a user might have a Rodauth configuration with `verify_login_change` enabled and a configuration without it enabled, side-by-side.

I have noticed a few other untranslateable keys to update (if I recall) so I may open more small PRs like this as I come across them

In the meantime, this is serving me well enough to intercept:

``` ruby
    change_login_notice_flash do
      if defined?(verify_login_change_path) # verify_login_change feature enabled
        translate(:verify_login_change_notice_flash, super())
      else
        super()
      end
    end
```