### PR TITLE
Fix setup of subsequent Webauthn identities

### DIFF
--- a/javascript/webauthn_auth.js
+++ b/javascript/webauthn_auth.js
@@ -1,34 +1,34 @@
 (function() {
+  var pack = function(v) { return btoa(String.fromCharCode.apply(null, new Uint8Array(e))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''); };
+  var unpack = function(v) { return Uint8Array.from(atob(v.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)); };
   var element = document.getElementById('webauthn-auth-form');
   var f = function(e) {
     //console.log(e);
     e.preventDefault();
     if (navigator.credentials) {
       var opts = JSON.parse(element.getAttribute("data-credential-options"));
-      opts.challenge = Uint8Array.from(atob(opts.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
-      opts.allowCredentials.forEach(function(cred) {
-        cred.id = Uint8Array.from(atob(cred.id.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
-      });
+      opts.challenge = unpack(opts.challenge);
+      opts.allowCredentials.forEach(function(cred) { cred.id = unpack(cred.id); });
       //console.log(opts);
       navigator.credentials.get({publicKey: opts}).
         then(function(cred){
           //console.log(cred);
           //window.cred = cred
 
-          var rawId = btoa(String.fromCharCode.apply(null, new Uint8Array(cred.rawId))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+          var rawId = pack(cred.rawId);
           var authValue = {
             type: cred.type,
             id: rawId,
             rawId: rawId,
             response: {
-              authenticatorData: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.authenticatorData))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''),
-              clientDataJSON: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.clientDataJSON))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''),
-              signature: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.signature))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+              authenticatorData: pack(cred.response.authenticatorData),
+              clientDataJSON: pack(cred.response.clientDataJSON),
+              signature: pack(cred.response.signature)
             }
           };
 
           if (cred.response.userHandle) {
-            authValue.response.userHandle = btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.userHandle))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+            authValue.response.userHandle = pack(cred.response.userHandle);
           }
 
           document.getElementById('webauthn-auth').value = JSON.stringify(authValue);

--- a/javascript/webauthn_setup.js
+++ b/javascript/webauthn_setup.js
@@ -9,6 +9,7 @@
       var opts = JSON.parse(element.getAttribute("data-credential-options"));
       opts.challenge = unpack(opts.challenge);
       opts.user.id = unpack(opts.user.id);
+      opts.excludeCredentials.forEach(function(cred) { cred.id = unpack(cred.id); });
       //console.log(opts);
       navigator.credentials.create({publicKey: opts}).
         then(function(cred){

--- a/javascript/webauthn_setup.js
+++ b/javascript/webauthn_setup.js
@@ -1,26 +1,28 @@
 (function() {
+  var pack = function(v) { return btoa(String.fromCharCode.apply(null, new Uint8Array(e))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''); };
+  var unpack = function(v) { return Uint8Array.from(atob(v.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)); };
   var element = document.getElementById('webauthn-setup-form');
   var f = function(e) {
     //console.log(e);
     e.preventDefault();
     if (navigator.credentials) {
       var opts = JSON.parse(element.getAttribute("data-credential-options"));
-      opts.challenge = Uint8Array.from(atob(opts.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
-      opts.user.id = Uint8Array.from(atob(opts.user.id.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
+      opts.challenge = unpack(opts.challenge);
+      opts.user.id = unpack(opts.user.id);
       //console.log(opts);
       navigator.credentials.create({publicKey: opts}).
         then(function(cred){
           //console.log(cred);
           //window.cred = cred
-          
-          var rawId = btoa(String.fromCharCode.apply(null, new Uint8Array(cred.rawId))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+          var rawId = pack(cred.rawId);
           document.getElementById('webauthn-setup').value = JSON.stringify({
             type: cred.type,
             id: rawId,
             rawId: rawId,
             response: {
-              attestationObject: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.attestationObject))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''),
-              clientDataJSON: btoa(String.fromCharCode.apply(null, new Uint8Array(cred.response.clientDataJSON))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+              attestationObject: pack(cred.response.attestationObject),
+              clientDataJSON: pack(cred.response.clientDataJSON)
             }
           });
           element.removeEventListener("submit", f);


### PR DESCRIPTION
The `webauthn` feature is designed to accommodate multiple Webauthn identies being created against a single Rodauth account. However, presently, this is broken because Rodauth is not correctly preparing the `excludeCredentials` option on credential creation options.

This PR does two things:

* Unpacks and prepares the correct representation for the credential IDs to exclude.
* Extracts the repeated packing and unpacking between (what appears to be) url-safe Base64 and the array buffer than the Webauthn browser API expects. This is purely opportunistic but it seemed like a subtle place for a bug to creep into in the future. I'm happy to excise this from the PR if you don't want this change.


There is no test for this because the Rodauth tests don't exercise JS (and Webauthn requires TLS connections anyway) so I literally have no idea how I could add a test for this.