### PR TITLE
`around_rodauth`

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -87,7 +87,9 @@ account_id :: The primary key value of the current account.
 account_session_value :: The primary value of the current account to store in the session when logging in.
 after_login :: Run arbitrary code after a successful login.
 after_login_failure :: Run arbitrary code after a login failure due to an invalid password.
+after_rodauth :: Run arbitrary code after handling any rodauth route
 already_logged_in :: What action to take if you are already logged in and attempt to access a page that only makes sense if you are not logged in.
+around_rodauth :: Run arbitrary code around handling any rodauth route
 authenticated? :: Whether the user has been authenticated. If multifactor authentication has been enabled for the account, this is true only if the session is multifactor authenticated.
 before_login :: Run arbitrary code after password has been checked, but before updating the session.
 before_login_attempt :: Run arbitrary code after an account has been located, but before the password has been checked.

--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -1,7 +1,7 @@
 = Documentation for Base Feature
 
 The base feature is automatically loaded when you use Rodauth.  It contains
-shared functionality that is used by multiple features. 
+shared functionality that is used by multiple features.
 
 == Auth Value Methods
 

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -121,6 +121,7 @@ module Rodauth
         request.is send(route_meth) do
           check_csrf if check_csrf?
           around_rodauth do
+            before_rodauth
             send(internal_handle_meth, request)
           end
         end
@@ -209,28 +210,6 @@ module Rodauth
         private meth, :"_#{meth}"
         auth_private_methods(meth)
       end
-    end
-
-    def around(name=feature_name)
-      meth = "around_#{name}"
-      class_eval(<<-RUBY, __FILE__, __LINE__)
-        def #{meth}
-          before_#{name} if defined?(before_#{name})
-          _#{meth} do
-            if defined?(super)
-              super
-            else
-              yield
-            end
-          end
-          nil
-        ensure
-          after_#{name} if defined?(after_#{name})
-        end
-      RUBY
-      class_eval("def _#{meth}; yield; end", __FILE__, __LINE__)
-      private meth, :"_#{meth}"
-      auth_private_methods(meth)
     end
 
     def additional_form_tags(name=feature_name)

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -120,8 +120,9 @@ module Rodauth
       define_method(handle_meth) do
         request.is send(route_meth) do
           check_csrf if check_csrf?
-          before_rodauth
-          send(internal_handle_meth, request)
+          around_rodauth do
+            send(internal_handle_meth, request)
+          end
         end
       end
 
@@ -208,6 +209,28 @@ module Rodauth
         private meth, :"_#{meth}"
         auth_private_methods(meth)
       end
+    end
+
+    def around(name=feature_name)
+      meth = "around_#{name}"
+      class_eval(<<-RUBY, __FILE__, __LINE__)
+        def #{meth}
+          before_#{name} if defined?(before_#{name})
+          _#{meth} do
+            if defined?(super)
+              super
+            else
+              yield
+            end
+          end
+          nil
+        ensure
+          after_#{name} if defined?(after_#{name})
+        end
+      RUBY
+      class_eval("def _#{meth}; yield; end", __FILE__, __LINE__)
+      private meth, :"_#{meth}"
+      auth_private_methods(meth)
     end
 
     def additional_form_tags(name=feature_name)

--- a/lib/rodauth/features/audit_logging.rb
+++ b/lib/rodauth/features/audit_logging.rb
@@ -30,6 +30,8 @@ module Rodauth
 
     def hook_action(hook_type, action)
       super
+      # rodauth action happens every request and so will dilute signal-to-noise of audit logs.
+      return if action == :rodauth
       # In after_logout, session is already cleared, so use before_logout in that case
       if (hook_type == :after || action == :logout) && (id = account ? account_id : session_value)
         add_audit_log(id, action)

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -7,7 +7,6 @@ module Rodauth
     before 'login'
     before 'login_attempt'
     before 'rodauth'
-    around 'rodauth'
     after 'rodauth'
 
     error_flash "Please login to continue", 'require_login'
@@ -113,7 +112,8 @@ module Rodauth
       :account_from_session,
       :field_attributes,
       :field_error_attributes,
-      :formatted_field_error
+      :formatted_field_error,
+      :around_rodauth
     )
 
     configuration_module_eval do
@@ -459,7 +459,15 @@ module Rodauth
       has_password? ? ['password'] : []
     end
 
+    def around_rodauth(&block)
+      _around_rodauth(&block)
+    end
+
     private
+
+    def _around_rodauth
+      yield
+    end
 
     def database_function_password_match?(name, hash_id, password, salt)
       db.get(Sequel.function(function_name(name), hash_id, BCrypt::Engine.hash_secret(password, salt)))

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -7,6 +7,8 @@ module Rodauth
     before 'login'
     before 'login_attempt'
     before 'rodauth'
+    around 'rodauth'
+    after 'rodauth'
 
     error_flash "Please login to continue", 'require_login'
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -500,19 +500,16 @@ describe 'Rodauth' do
         super()
         hooks << :before
       end
-      around_rodauth do |&blk|
+      around_rodauth do |&block|
+        super(&block)
+      ensure
         hooks << :around
-        blk.call
-      end
-      after_rodauth do
-        super()
-        hooks << :after
       end
     end
     roda do |r|
       r.rodauth
     end
     visit '/login'
-    hooks.must_equal [:before, :around, :after]
+    hooks.must_equal [:before, :around]
   end
 end


### PR DESCRIPTION
This PR adds an `around_rodauth` extension point for features to use. It allows a feature (such as the one provided by `rodauth-rails`) to conditionally allow the request to proceed (e.g. if a Rails-owned `before_action` has rendered or redirected).

I think the final design here is as you indicated on the mailing list @jeremyevans, but `&block` needs to be explicitly passed to `super()` because implicit `super` args are not available in the dynamic context.

cc @janko  