### PR TITLE
Avoid features being loaded multiple times

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -290,9 +290,11 @@ module Rodauth
     end
 
     def enable(*features)
-      new_features = features - @auth.features
-      new_features.each{|f| load_feature(f)}
-      @auth.features.concat(new_features)
+      features.each do |feature|
+        next if @auth.features.include?(feature)
+        load_feature(feature)
+        @auth.features << feature
+      end
     end
 
     private

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -325,16 +325,28 @@ describe 'Rodauth' do
     page.current_path.must_equal '/logout'
   end
 
-  it "should have rodauth.features and rodauth.session_value work when not logged in" do
+  it "should have rodauth.session_value work when not logged in" do
     rodauth do
       enable :login
     end
     roda do |r|
-      "#{rodauth.features.first.inspect}#{rodauth.session_value.inspect}"
+      rodauth.session_value.inspect
     end
 
     visit '/'
-    page.body.must_equal ':loginnil'
+    page.body.must_equal 'nil'
+  end
+
+  it "should have rodauth.features return list of enabled features" do
+    rodauth do
+      enable :create_account, :verify_account, :login
+    end
+    roda do |r|
+      rodauth.features.join(",")
+    end
+
+    visit '/'
+    page.body.must_equal 'login,login_password_requirements_base,create_account,email_base,verify_account'
   end
 
   it "should support auth_class_eval for evaluation inside Auth class" do


### PR DESCRIPTION
When loading a tree of dependencies, we need to immediately write down when we've loaded the dependency, otherwise in this case they can be loaded multiple times. I've added a spec that would return duplicate features with current code.

It doesn't cause any actual problems, but users of `rodauth.features` and `rodauth.routes` might rely that every feature is listed exactly once. In my case, I'm using these methods to list available routes.
