### PR TITLE
Improve routing syntax consistency in confirm_password feature

### DIFF
--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -26,11 +26,11 @@ module Rodauth
       require_account_session
       before_confirm_password_route
 
-      request.get do
+      r.get do
         confirm_password_view
       end
 
-      request.post do
+      r.post do
         if password_match?(param(password_param))
           transaction do
             before_confirm_password


### PR DESCRIPTION
This PR does a minor update to the routing syntax in confirm_password feature to make it consistent with other Rodauth features.
