### PR TITLE
Return unauthorized status instead of bad request when access_token e…

### DIFF
--- a/doc/jwt_refresh.rdoc
+++ b/doc/jwt_refresh.rdoc
@@ -47,6 +47,8 @@ jwt_refresh_token_key_param :: Name of parameter in which the refresh token is p
 jwt_refresh_token_table :: Name of the table holding refresh token keys.
 jwt_refresh_without_access_token_message :: Error message when trying to refresh with providing an access token.
 jwt_refresh_without_access_token_status :: The HTTP status code to use when trying to refresh without providing an access token.
+expired_jwt_access_token_status :: The HTTP status code to use when a access token (JWT) is expired is submitted in the Authorization header. Default is 400 for backwards compatibility, and it is recommended to set it to 401.
+expired_jwt_access_token_message :: The error message to use when a access token (JWT) is expired is submitted in the Authorization header.
 
 == Auth Methods
 

--- a/doc/jwt_refresh.rdoc
+++ b/doc/jwt_refresh.rdoc
@@ -30,6 +30,8 @@ This feature depends on the jwt feature.
 == Auth Value Methods
 
 allow_refresh_with_expired_jwt_access_token? :: Whether refreshing should be allowed with an expired access token. Default is +false+.  You must set an +hmac_secret+ if setting this value to +true+.
+expired_jwt_access_token_status :: The HTTP status code to use when a access token (JWT) is expired is submitted in the Authorization header. Default is 400 for backwards compatibility, and it is recommended to set it to 401.
+expired_jwt_access_token_message :: The error message to use when a access token (JWT) is expired is submitted in the Authorization header.
 jwt_access_token_key :: Name of the key in the response json holding the access token.  Default is +access_token+.
 jwt_access_token_not_before_period :: How many seconds before the current time will the jwt be considered valid (to account for inaccurate clocks). Default is 5.
 jwt_access_token_period :: Validity of an access token in seconds, default is 1800 (30 minutes).
@@ -47,8 +49,6 @@ jwt_refresh_token_key_param :: Name of parameter in which the refresh token is p
 jwt_refresh_token_table :: Name of the table holding refresh token keys.
 jwt_refresh_without_access_token_message :: Error message when trying to refresh with providing an access token.
 jwt_refresh_without_access_token_status :: The HTTP status code to use when trying to refresh without providing an access token.
-expired_jwt_access_token_status :: The HTTP status code to use when a access token (JWT) is expired is submitted in the Authorization header. Default is 400 for backwards compatibility, and it is recommended to set it to 401.
-expired_jwt_access_token_message :: The error message to use when a access token (JWT) is expired is submitted in the Authorization header.
 
 == Auth Methods
 

--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -25,7 +25,7 @@ module Rodauth
     translatable_method :jwt_refresh_without_access_token_message, 'no JWT access token provided during refresh'
     auth_value_method :jwt_refresh_without_access_token_status, 401
     translatable_method :expired_jwt_access_token_message, "expired JWT access token"
-    auth_value_method :jwt_access_expired_status, 401
+    auth_value_method :expired_jwt_access_token_status, 400
 
     auth_private_methods(
       :account_from_refresh_token
@@ -94,20 +94,13 @@ module Rodauth
 
     private
 
-    def jwt_payload!
-      _jwt_payload
-    rescue JWT::DecodeError => e
-      message, status = invalid_jwt_format_error_message, json_response_error_status
-
-      if e.instance_of?(JWT::ExpiredSignature)
-        message, status = expired_jwt_access_token_message, jwt_access_expired_status
+    def rescue_jwt_payload
+      if $!.instance_of?(JWT::ExpiredSignature)
+        json_response[json_response_error_key] = expired_jwt_access_token_message
+        response.status ||= expired_jwt_access_token_status
       end
 
-      json_response[json_response_error_key] = message
-      response.status ||= status
-      response['Content-Type'] ||= json_response_content_type
-      response.write(_json_response_body(json_response))
-      request.halt
+      super
     end
 
     def _account_from_refresh_token(token)

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -368,10 +368,10 @@ describe 'Rodauth login feature' do
     period = 1800
 
     res = json_request("/jwt-refresh", :refresh_token=>refresh_token)
-    res.must_equal [400, {"error"=>"invalid JWT format or claim in Authorization header"}]
+    res.must_equal [401, {"error"=>"expired JWT access token"}]
 
     res = json_request('/')
-    res.must_equal [400, {"error"=>"invalid JWT format or claim in Authorization header"}]
+    res.must_equal [401, {"error"=>"expired JWT access token"}]
   end
 
   it "should allow refreshing token when providing expired access token if configured" do

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -355,6 +355,7 @@ describe 'Rodauth login feature' do
       enable :login, :logout, :jwt_refresh, :close_account
       jwt_secret '1'
       jwt_access_token_period{period}
+      expired_jwt_access_token_status 401
     end
     roda(:jwt) do |r|
       r.rodauth


### PR DESCRIPTION
…xpired to jwt_refresh feature, for inform the client about the need to refresh tokens

* The scheme of work of `access_token` with `refresh_token` in many respects ideologically repeats oauth. The Oauth documentation https://tools.ietf.org/html/rfc6750 for the Bearer case describes that a 401 error should be returned for an expired access token. I think that the use of 401 status in this case is convenient in order to distinguish an expired access token from other cases, and thus inform the user that it is time for him to refresh a couple of tokens.