### PR TITLE
Default remember cookie path to "/"

### DIFF
--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -35,7 +35,7 @@ raw_remember_token_deadline :: A deadline before which to allow a raw remember t
 remember_additional_form_tags :: HTML fragment containing additional form tags to use on the change remember setting form.
 remember_button :: The text to use for the change remember settings button.
 remember_cookie_key :: The cookie name to use for the remember token.
-remember_cookie_options :: Any options to set for the remember cookie.
+remember_cookie_options :: Any options to set for the remember cookie. By default, the `:path` cookie option is set to `/`.
 remember_deadline_column :: The column name in the +remember_table+ storing the deadline after which the token will be ignored.
 remember_deadline_interval :: The amount of time for which to remember accounts, 14 days by default.  Only used if +set_deadline_values?+ is true.
 remember_disable_label :: The label for disabling remembering.

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -132,11 +132,14 @@ module Rodauth
       opts = Hash[remember_cookie_options]
       opts[:value] = "#{account_id}_#{convert_token_key(remember_key_value)}"
       opts[:expires] = convert_timestamp(active_remember_key_ds.get(remember_deadline_column))
+      opts[:path] = "/" unless opts.key?(:path)
       ::Rack::Utils.set_cookie_header!(response.headers, remember_cookie_key, opts)
     end
 
     def forget_login
-      ::Rack::Utils.delete_cookie_header!(response.headers, remember_cookie_key, remember_cookie_options)
+      opts = Hash[remember_cookie_options]
+      opts[:path] = "/" unless opts.key?(:path)
+      ::Rack::Utils.delete_cookie_header!(response.headers, remember_cookie_key, opts)
     end
 
     def get_remember_key


### PR DESCRIPTION
Cookies without a path behave unexpected on requests with multiple path components. When a `/a/b/c` request sets a cookie, that cookie appears to be stored for `/a/b` path. This cookie is visible in the inspector on Firefox, but not on Chrome. Attempting to delete the cookie doesn't work, because a subsequent request to `/a/b` still sends the cookie (but not a request to `/` or any other route). See [this StackOverFlow answer](https://stackoverflow.com/a/64515458/988414) for more details.

This can cause unexpected behaviour when using `#load_memory` before each request, as the user that has manually signed out can be autologged back in from the remember cookie if a request is made to a certain path.

Setting cookie path to `/` resolves this issue. Rails does this by default for its cookies as well.
