### PR TITLE
Add :auto_remove_recovery_codes? option to RecoveryCodes feature

### DIFF
--- a/doc/recovery_codes.rdoc
+++ b/doc/recovery_codes.rdoc
@@ -18,6 +18,7 @@ add_recovery_codes_heading :: Text to use for heading above the form to add reco
 add_recovery_codes_page_title :: The page title to use on the add recovery codes form.
 add_recovery_codes_param :: The parameter name to use for adding recovery codes.
 auto_add_recovery_codes? :: Whether to automatically add recovery codes (or any missing recovery codes) when another multifactor authentication type is enabled (false by default).
+auto_remove_recovery_codes? :: Whether to automatically remove recovery codes when the last multifactor authentication type has been disabled (false by default).
 invalid_recovery_code_error_flash :: The flash error to show when an invalid recovery code is used.
 invalid_recovery_code_message :: The error message to show when an invalid recovery code is used.
 recovery_auth_additional_form_tags :: HTML fragment containing additional form tags when authenticating via a recovery code.

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -150,14 +150,17 @@ module Rodauth
     end
 
     def after_otp_disable
+      super if defined?(super)
       auto_remove_recovery_codes
     end
 
     def after_sms_disable
+      super if defined?(super)
       auto_remove_recovery_codes
     end
 
     def after_webauthn_remove
+      super if defined?(super)
       auto_remove_recovery_codes
     end
 

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -34,6 +34,7 @@ module Rodauth
     auth_value_method :add_recovery_codes_param, 'add'
     translatable_method :add_recovery_codes_heading, '<h2>Add Additional Recovery Codes</h2>'
     auth_value_method :auto_add_recovery_codes?, false
+    auth_value_method :auto_remove_recovery_codes?, false
     translatable_method :invalid_recovery_code_message, "Invalid recovery code"
     auth_value_method :recovery_codes_limit, 16
     auth_value_method :recovery_codes_column, :code
@@ -148,6 +149,18 @@ module Rodauth
       auto_add_missing_recovery_codes
     end
 
+    def after_otp_disable
+      auto_remove_recovery_codes
+    end
+
+    def after_sms_disable
+      auto_remove_recovery_codes
+    end
+
+    def after_webauthn_remove
+      auto_remove_recovery_codes
+    end
+
     def recovery_codes_remove
       recovery_codes_ds.delete
     end
@@ -224,6 +237,12 @@ module Rodauth
     def auto_add_missing_recovery_codes
       if auto_add_recovery_codes?
         add_recovery_codes(recovery_codes_limit - recovery_codes.length)
+      end
+    end
+
+    def auto_remove_recovery_codes
+      if auto_remove_recovery_codes? && possible_authentication_methods.length == 2
+        recovery_codes_remove
       end
     end
 


### PR DESCRIPTION
This adds an `auto_remove_recovery_codes?` option to the `recovery_codes` feature. It defaults to `false`. If set to `true` it will delete all recovery codes once the last MFA method (SMS, OTP or WebAuthn) has been removed. It won't delete recovery codes if an MFA method is removed and others are still active (e.g. disable OTP with SMS still being active).