### PR TITLE
Allow Rodauth features to be in custom location

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -300,7 +300,7 @@ module Rodauth
     private
 
     def load_feature(feature_name)
-      require "rodauth/features/#{feature_name}"
+      require "rodauth/features/#{feature_name}" unless FEATURES[feature_name]
       feature = FEATURES[feature_name]
       enable(*feature.dependencies)
       extend feature.configuration

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -349,6 +349,23 @@ describe 'Rodauth' do
     page.body.must_equal 'login,login_password_requirements_base,create_account,email_base,verify_account'
   end
 
+  it "should allow enabling custom features that have already been loaded" do
+    require "rodauth"
+    Rodauth::Feature.define(:foo) {}
+
+    rodauth do
+      enable :foo
+    end
+    roda do |r|
+      rodauth.features.join(",")
+    end
+
+    visit '/'
+    page.body.must_equal 'foo'
+
+    Rodauth::FEATURES.delete(:foo)
+  end
+
   it "should support auth_class_eval for evaluation inside Auth class" do
     rodauth do
       enable :login


### PR DESCRIPTION
This allows manually loading Rodauth features before enabling them, allowing them to be in a location other than `rodauth/features/<feature>.rb` in the load path.

I would find this useful in rodauth-rails, where I have everything nested in `rodauth/rails/*`, including the `rails` feature which is at `rodauth/rails/feature.rb`. At the moment I also have `lib/rodauth/features/rails.rb`, which just requires that file, but it would be nice to be able to remove it.
