### PR TITLE
Fix bug where no deadline is set, but is used by default from the database

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -709,11 +709,9 @@ module Rodauth
     # This is needed on MySQL, which doesn't support non constant defaults other than
     # CURRENT_TIMESTAMP.
     def set_deadline_value(hash, column, interval)
-      if set_deadline_values?
-        # :nocov:
-        hash[column] = Sequel.date_add(Sequel::CURRENT_TIMESTAMP, interval)
-        # :nocov:
-      end
+      # :nocov:
+      hash[column] = Sequel.date_add(Sequel::CURRENT_TIMESTAMP, interval)
+      # :nocov:
     end
 
     def set_session_value(key, value)


### PR DESCRIPTION
* Recently I noticed that in all cases, when logging in with the `jwt_refresh` functions, the token deadline is assigned 1 day, regardless of the setting `jwt_refresh_token_deadline_interval`