### PR TITLE
Fix #clear_session not clearing JWT session with sessions plugin

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -73,7 +73,10 @@ module Rodauth
 
     def clear_session
       super
-      set_jwt if use_jwt?
+      if use_jwt?
+        session.clear
+        set_jwt
+      end
     end
 
     def set_field_error(field, message)

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -287,6 +287,31 @@ describe 'Rodauth login feature' do
     json_request[1].must_equal [nil, true]
   end
 
+  it "should return empty JWT token after calling #clear_session" do
+    rodauth do
+      enable :login
+    end
+    roda(:jwt_html) do |r|
+      r.rodauth
+      r.post('clear') do
+        rodauth.clear_session
+        rodauth.session
+      end
+      r.post('') do
+        rodauth.session
+      end
+    end
+
+    json_login
+
+    res = json_request '/clear', include_headers: true
+    res[1]['Authorization'].wont_be_nil
+    res[2].must_equal({})
+
+    res = json_request '/'
+    res[1].must_equal({})
+  end
+
   it "should have field error and error flash work correctly when using jwt feature for non-jwt requests" do
     mpl = false
     rodauth do


### PR DESCRIPTION
When sessions Roda plugin is used, `#clear_session` will call `scope.clear_session`, which unlike `session.clear` will not clear the `@session` hash.

So in JWT feature we make sure to call `session.clear` in `#clear_session` in case it wasn't called in the super method. I wasn't sure whether to add an `if scope.respond_to?(:clear_session)` here, I thought it probably wasn't worth repeating the conditional.

I also added assertions for setting empty JWT token when `#clear_session` is called but Rodauth isn't the one returning the response to the client. As I mentioned on the google group, this spec was actually the main purpose of my PR 😛 But then I discovered this potential issue through reading, so I thought I'd include a fix.