### PR TITLE
Use jwt_refresh_token_key in #update_session override

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -177,8 +177,7 @@ module Rodauth
     end
 
     def remove_jwt_refresh_token_key(token)
-      account_id, token = split_token(token)
-      token_id, _ = split_token(token)
+      account_id, token_id, _ = _account_refresh_token_split(token)
       jwt_refresh_token_account_token_ds(account_id, token_id).delete
     end
 
@@ -210,9 +209,7 @@ module Rodauth
           id, token_id, key = _account_refresh_token_split(token)
 
           if id && token_id && key && (actual = get_active_refresh_token(session_value, token_id)) && timing_safe_eql?(key, convert_token_key(actual))
-            jwt_refresh_token_account_ds(id).
-              where(jwt_refresh_token_id_column=>token_id).
-              delete
+            jwt_refresh_token_account_token_ds(id, token_id).delete
           end
         end
       end

--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -65,7 +65,7 @@ module Rodauth
       # JWT login puts the access token in the header.
       # We put the refresh token in the body.
       # Note, do not put the access_token in the body here, as the access token content is not yet finalised.
-      token = json_response['refresh_token'] = generate_refresh_token
+      token = json_response[jwt_refresh_token_key] = generate_refresh_token
 
       set_jwt_refresh_token_hmac_session_key(token)
     end


### PR DESCRIPTION
I noticed this while reading the code, and I think `jwt_refresh_token_key` was meant to be used in `#update_session` override instead of the `'refresh_token'` string.

I've also noticed a few methods could be reused, so I included these changes in the PR as well.
