### PR TITLE
Forbid JavaScript from accessing remember cookie

### DIFF
--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -35,7 +35,7 @@ raw_remember_token_deadline :: A deadline before which to allow a raw remember t
 remember_additional_form_tags :: HTML fragment containing additional form tags to use on the change remember setting form.
 remember_button :: The text to use for the change remember settings button.
 remember_cookie_key :: The cookie name to use for the remember token.
-remember_cookie_options :: Any options to set for the remember cookie. By default, the `:path` cookie option is set to `/`.
+remember_cookie_options :: Any options to set for the remember cookie. By default, the `:path` cookie option is set to `/`, and `:httponly` is set to `true`.
 remember_deadline_column :: The column name in the +remember_table+ storing the deadline after which the token will be ignored.
 remember_deadline_interval :: The amount of time for which to remember accounts, 14 days by default.  Only used if +set_deadline_values?+ is true.
 remember_disable_label :: The label for disabling remembering.

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -133,6 +133,7 @@ module Rodauth
       opts[:value] = "#{account_id}_#{convert_token_key(remember_key_value)}"
       opts[:expires] = convert_timestamp(active_remember_key_ds.get(remember_deadline_column))
       opts[:path] = "/" unless opts.key?(:path)
+      opts[:httponly] = true unless opts.key?(:httponly)
       ::Rack::Utils.set_cookie_header!(response.headers, remember_cookie_key, opts)
     end
 


### PR DESCRIPTION
Currently the remember cookie can be retrieved via `document.cookie`, which opens the surface for attacks if the app using Rodauth has a XSS vulnerability, as it allowing malicious JavaScript code to steal the remember token and the attacker to login to the user's account.

We mitigate this attack by setting `HttpOnly` for the remember cookie, which forbids JavaScript from accessing the cookie. This should not break code for most apps, because the client generally doesn't need to read this value, it only needs to send the cookie to the server (which happens automatically).
