### PR TITLE
Make remember cookie secure by default with SSL

### DIFF
--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -134,6 +134,7 @@ module Rodauth
       opts[:expires] = convert_timestamp(active_remember_key_ds.get(remember_deadline_column))
       opts[:path] = "/" unless opts.key?(:path)
       opts[:httponly] = true unless opts.key?(:httponly)
+      opts[:secure] = true unless opts.key?(:secure) || !request.ssl?
       ::Rack::Utils.set_cookie_header!(response.headers, remember_cookie_key, opts)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -297,11 +297,19 @@ class Minitest::HooksSpec
   end
 
   def get_cookie(key)
-    page.driver.browser.rack_mock_session.cookie_jar[key]
+    cookie_jar[key]
+  end
+
+  def retrieve_cookie(key)
+    yield cookie_jar.get_cookie(key) if cookie_jar.respond_to?(:get_cookie)
   end
 
   def set_cookie(key, value)
-    page.driver.browser.rack_mock_session.cookie_jar[key] = value
+    cookie_jar[key] = value
+  end
+
+  def cookie_jar
+    page.driver.browser.rack_mock_session.cookie_jar
   end
 
   def json_request(path='/', params={})


### PR DESCRIPTION
Secure cookies are only sent to the server when a request is made with the HTTPS scheme, and therefore are more resistant to man-in-the-middle attacks, [according to MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie). Given this, I thought it might be safer make the remember cookie `secure` by default when the request is made over SSL.

I believe this is mostly a backwards compatible change, except for sites that are accessible both over `http://` and `https://`, where `http://` doesn't redirect to `https://`. However, this configuration is insecure by itself, so I thought it's fine.

I've also took the liberty of DRYing up remember feature tests a bit, and moving assertions for all cookie attributes together in a dedicated test.
