### PR TITLE
Improve Rodauth::Auth inheritance

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -295,9 +295,8 @@ module Rodauth
 
     def enable(*features)
       features.each do |feature|
-        next if @auth.features.include?(feature)
         load_feature(feature)
-        @auth.features << feature
+        @auth.features << feature unless @auth.features.include?(feature)
       end
     end
 
@@ -309,7 +308,7 @@ module Rodauth
       enable(*feature.dependencies)
       extend feature.configuration
 
-      @auth.routes.concat(feature.routes)
+      @auth.routes |= feature.routes
       @auth.send(:include, feature)
     end
   end

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -257,18 +257,21 @@ module Rodauth
   class Auth
     class << self
       attr_accessor :roda_class
-      attr_reader :features
-      attr_reader :routes
+      attr_accessor :features
+      attr_accessor :routes
       attr_accessor :route_hash
     end
 
+    @features = []
+    @routes = []
+    @route_hash = {}
+
     def self.inherited(subclass)
       super
-      subclass.instance_exec do
-        @features = []
-        @routes = []
-        @route_hash = {}
-      end
+      subclass.roda_class = roda_class
+      subclass.features = features.dup
+      subclass.routes = routes.dup
+      subclass.route_hash = route_hash.dup
     end
 
     def self.configure(&block)

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -1,6 +1,25 @@
 require_relative 'spec_helper'
 
 describe 'Rodauth' do
+  it "should support configuring a feature multiple times" do
+    require "rodauth"
+
+    auth_class = Class.new(Rodauth::Auth)
+    auth_class.roda_class = Class.new(Roda)
+    auth_class.configure do
+      enable :login
+      login_redirect "/"
+    end
+
+    auth_class.configure do
+      enable :login
+      use_multi_phase_login? true
+    end
+
+    auth_class.features.must_equal [:login]
+    auth_class.routes.must_equal [:handle_login]
+  end
+
   it "should keep private methods private when overridden" do
     rodauth do
       use_database_authentication_functions? false

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -1,6 +1,29 @@
 require_relative 'spec_helper'
 
 describe 'Rodauth' do
+  it "should support inheritance" do
+    require "rodauth"
+
+    auth_class = Class.new(Rodauth::Auth)
+    auth_class.roda_class = Class.new(Roda)
+    auth_class.configure { enable :login }
+
+    auth_subclass = Class.new(auth_class)
+    auth_subclass.configure do
+      enable :login, :logout
+      login_route "sign-in"
+      logout_route "sign-out"
+    end
+    auth_subclass.roda_class.must_equal auth_class.roda_class
+    auth_subclass.features.must_equal [:login, :logout]
+    auth_subclass.routes.must_equal [:handle_login, :handle_logout]
+    auth_subclass.route_hash.must_equal Hash["/sign-in" => :handle_login, "/sign-out" => :handle_logout]
+
+    auth_class.features.must_equal [:login]
+    auth_class.routes.must_equal [:handle_login]
+    auth_class.route_hash.must_equal Hash["/login" => :handle_login]
+  end
+
   it "should support configuring a feature multiple times" do
     require "rodauth"
 


### PR DESCRIPTION
I'm working on adding support to rodauth-rails for defining `Rodauth::Auth` subclasses directly, and hooking them into the Roda app. Essentially something like this:

```rb
class RodauthMain < Rodauth::Auth
  configure do
    # ... main user logic ...
  end
end
```
```rb
class RodauthAdmin < Rodauth::Auth
  configure do
    # ... admin logic ...
  end
end
```
```rb
class RodauthApp < Roda
  opts[:rodauths] = {
    nil    => RodauthMain,
    :admin => RodauthAdmin,
  }

  plugin :rodauth do
    # nothing, just to load the plugin
  end
end
```

This kind of setup would provide several advantages for the user:

* authenication logic for different configurations can be easily separated into different files (and separated from routing logic)

* common logic can be shared between configurations using inheritance

  ```rb
  class RodauthBase < Rodauth::Auth
    # common logic
  end
  class RodauthMain < RodauthBase
    # ...
  end
  class RodauthAdmin < RodauthBase
    # ...
  end
  ```

* it's more natural to define additional methods on the Rodauth object

  ```rb
  class RodauthMain < Rodauth::Auth
    configure do
      # this works, but it's a bit strange and nested
      auth_class_eval do
        def admin?
          # ...
        end
      end
    end

    # this is regular way how methods are defined, which is familar to everyone
    def admin?
      # ...
    end
  end
  ```

* the `Rodauth::Auth` subclass is named with a constant instead of being an anonymous class, which makes for better exception reports in `NoMethodError` situations

To make multiple levels of inheritance work, I've modified `Rodauth::Auth` to initialize class instance variables upfront, and assign a copy of them to the subclass. With that I also wanted to make loading the same feature multiple times work, in case the user wants to tweak an already loaded feature in the subclass (I also almost needed this behaviour in rodauth-rails regardless of the inheritance-related changes). The commit messages provide more details.
