### PR TITLE
Cache the configuration object in Rodauth::Auth

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -268,11 +268,12 @@ module Rodauth
         @features = []
         @routes = []
         @route_hash = {}
+        @configuration = Configuration.new(self)
       end
     end
 
     def self.configure(&block)
-      Configuration.new(self, &block)
+      @configuration.apply(&block)
     end
 
     def self.freeze
@@ -288,6 +289,10 @@ module Rodauth
 
     def initialize(auth, &block)
       @auth = auth
+      apply(&block) if block
+    end
+
+    def apply(&block)
       load_feature(:base)
       instance_exec(&block)
       auth.allocate.post_configure

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -80,6 +80,24 @@ describe 'Rodauth' do
     page.title.must_equal 'FooRP'
   end
 
+  it "should reuse the configuration object" do
+    @no_freeze = true
+    rodauth do
+      enable :login
+      login_page_title 'My Title'
+    end
+    roda do |r|
+      r.rodauth
+    end
+    @app.plugin :rodauth do
+      login_button 'My Button'
+    end
+
+    visit '/login'
+    page.title.must_equal 'My Title'
+    page.find("[type=submit]").value.must_equal 'My Button'
+  end
+
   it "should support route paths and URLs with prefix and query parameters" do
     block = proc{''}
     prefix = ''


### PR DESCRIPTION
As discussed in https://github.com/jeremyevans/rodauth/pull/151, this PR modifies `Rodauth::Auth` to cache the `Configuration` object, and reuse it for each `.configure` call. This behaviour provides more flexibility in some scenarios, and makes it easier for a library to extend `Rodauth::Auth` with improved inheritance behaviour.
