### PR TITLE
Add :auth_class plugin option for providing a specific Rodauth::Auth subclass

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -852,6 +852,9 @@ which configures which dependent plugins should be loaded. Options:
          still need to load the render plugin manually.
 :name :: Provide a name for the given Rodauth configuration, used to
          support multiple Rodauth configurations in a given Roda application.
+:auth_class :: Provide a specific `Rodauth::Auth` subclass that should be set
+               on the Roda application. By default, an anonymous
+               `Rodauth::Auth` subclass is created.
 
 === Feature Documentation
 

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -39,7 +39,7 @@ module Rodauth
     else
       json_opt != :only
     end
-    auth_class = (app.opts[:rodauths] ||= {})[opts[:name]] ||= Class.new(Auth)
+    auth_class = (app.opts[:rodauths] ||= {})[opts[:name]] ||= opts[:auth_class] || Class.new(Auth)
     if !auth_class.roda_class
       auth_class.roda_class = app
     elsif auth_class.roda_class != app

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -98,6 +98,21 @@ describe 'Rodauth' do
     page.find("[type=submit]").value.must_equal 'My Button'
   end
 
+  it "should allow setting Rodauth::Auth subclass with :auth_class option" do
+    require "rodauth"
+
+    auth_class = Class.new(Rodauth::Auth)
+    rodauth do
+      enable :login
+    end
+    roda(auth_class: auth_class) do |r|
+      r.rodauth
+    end
+
+    @app.rodauth.must_equal auth_class
+    auth_class.features.must_equal [:login]
+  end
+
   it "should support route paths and URLs with prefix and query parameters" do
     block = proc{''}
     prefix = ''


### PR DESCRIPTION
As discussed in https://github.com/jeremyevans/rodauth/pull/151, this PR adds an `:auth_class` plugin option that allows providing a custom `Rodauth::Auth` subclass. Let's say the user has the `Rodauth::Auth` subclasses defined as follows:

```rb
class RodauthMain < Rodauth::Auth
  configure do
    # ...
  end
end
```
```rb
class RodauthAdmin < Rodauth::Auth
  configure do
    # ...
  end
end
```

Previously it was possible to specify these classes by overriding `opts[:rodauths]`:

```rb
class RodauthApp < Roda
  opts[:rodauths] = {
    nil => RodauthMain,
    :admin => RodauthAdmin,
  }

  plugin :rodauth do
    # just to load the plugin
  end
end
```

The new `:auth_class` option makes this easier:

```rb
class RodauthApp < Roda
  plugin :rodauth, auth_class: RodauthMain do
    # ..
  end

  plugin :rodauth, name: :admin, auth_class: RodauthAdmin do
    # ...
  end
end
```
