### PR TITLE
Use new-password autocomplete value for password field when resetting password

### DIFF
--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -100,6 +100,7 @@ module Rodauth
     route do |r|
       check_already_logged_in
       before_reset_password_route
+      @password_field_autocomplete_value = 'new-password'
 
       r.get do
         if key = param_or_nil(reset_password_key_param)

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -73,6 +73,7 @@ describe 'Rodauth reset_password feature' do
 
       visit link
       page.title.must_equal 'Reset Password'
+      page.find_by_id('password')[:autocomplete].must_equal 'new-password'
 
       fill_in 'Password', :with=>'0123456'
       fill_in 'Confirm Password', :with=>'0123456789'


### PR DESCRIPTION
Set @password_field_autocomplete_value = 'new-password' for the reset-password feature