### PR TITLE
Allow not passing a block when loading the plugin

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -46,7 +46,7 @@ module Rodauth
       auth_class = app.opts[:rodauths][opts[:name]] = Class.new(auth_class)
       auth_class.roda_class = app
     end
-    auth_class.configure(&block)
+    auth_class.configure(&block) if block
   end
 
   FEATURES = {}

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -113,6 +113,12 @@ describe 'Rodauth' do
     auth_class.features.must_equal [:login]
   end
 
+  it "should not require passing a block when loading the plugin" do
+    app = Class.new(Base)
+    app.plugin :rodauth
+    app.rodauth.superclass.must_equal(Rodauth::Auth)
+  end
+
   it "should support route paths and URLs with prefix and query parameters" do
     block = proc{''}
     prefix = ''


### PR DESCRIPTION
When using the approach of passing `Rodauth::Auth` subclasses explicitly via the `:auth_class` option, the auth class would be configured already, so in this case it would be convenient to be able to skip passing the block when loading the plugin.

```rb
class RodauthMain < Rodauth::Auth
  configure do
    # ...
  end
end
```
```rb
plugin :rodauth, auth_class: RodauthMain
```

I was thinking whether I should move this into `Rodauth::Auth.configure`, or still require the block when `:auth_class` is not passed in, so that it's not possible to set up a `Rodauth::Auth` subclass without the `:base` feature loaded. What are your thoughts on this?
