### PR TITLE
Translate remaining error messages in ChangeLogin and LoginPasswordRequirementsBase

### DIFF
--- a/lib/rodauth/features/change_login.rb
+++ b/lib/rodauth/features/change_login.rb
@@ -6,6 +6,7 @@ module Rodauth
 
     notice_flash 'Your login has been changed'
     error_flash 'There was an error changing your login'
+    translatable_method :same_as_current_login_message, 'same as current login'
     loaded_templates %w'change-login login-field login-confirm-field password-field'
     view 'change-login', 'Change Login'
     after
@@ -64,7 +65,7 @@ module Rodauth
 
     def change_login(login)
       if account_ds.get(login_column).downcase == login.downcase
-        @login_requirement_message = 'same as current login'
+        @login_requirement_message = same_as_current_login_message
         return false
       end
 

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -16,6 +16,7 @@ module Rodauth
     auth_value_method :require_login_confirmation?, true
     auth_value_method :require_password_confirmation?, true
     translatable_method :same_as_existing_password_message, "invalid password, same as current password"
+    translatable_method :contains_null_byte_message, 'contains null byte'
 
     auth_value_methods(
       :login_confirm_label,
@@ -124,7 +125,7 @@ module Rodauth
 
     def password_does_not_contain_null_byte?(password)
       return true unless password.include?("\0")
-      @password_requirement_message = 'contains null byte'
+      @password_requirement_message = contains_null_byte_message
       false
     end
 


### PR DESCRIPTION
Found two messages, which wasn't translatable through `translate` method