### PR TITLE
Set a reason code when an error happens

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -109,6 +109,7 @@ set_notice_flash(message) :: Set the next notice flash to the given message.
 set_notice_now_flash(message) :: Set the current notice flash to the given message.
 set_redirect_error_flash(message) :: Set the next error flash to the given message.
 set_title(title) :: Set the title of the page to the given title.
+set_error_reason(reason) :: Set the current error reason code. You can override this method to add this reason to customize the response depending on the exact error.
 translate(key, default_value) :: Return a translated version for the key (uses the default value by default).
 unverified_account_message :: The message to use when attempting to login to an unverified account.
 update_session :: Clear the session, then set the session key to the primary key of the current account.

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -540,6 +540,11 @@ module Rodauth
     def set_response_error_status(status)
       response.status = status
     end
+    
+    def set_response_error_reason_status(reason, status)
+      set_error_reason(reason)
+      set_response_error_status(status)
+    end
 
     def throw_error(field, error)
       set_field_error(field, error)

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -100,6 +100,7 @@ module Rodauth
       :set_notice_flash,
       :set_notice_now_flash,
       :set_redirect_error_flash,
+      :set_error_reason,
       :set_title,
       :translate,
       :update_session
@@ -548,6 +549,14 @@ module Rodauth
     def throw_error_status(status, field, error)
       set_response_error_status(status)
       throw_error(field, error)
+    end
+
+    def set_error_reason(reason)
+    end
+
+    def throw_error_reason(reason, status, field, message)
+      set_error_reason(reason)
+      throw_error_status(status, field, message)
     end
 
     def use_date_arithmetic?

--- a/lib/rodauth/features/change_login.rb
+++ b/lib/rodauth/features/change_login.rb
@@ -30,16 +30,16 @@ module Rodauth
       r.post do
         catch_error do
           if change_login_requires_password? && !password_match?(param(password_param))
-            throw_error_status(invalid_password_error_status, password_param, invalid_password_message)
+            throw_error_reason(:invalid_password, invalid_password_error_status, password_param, invalid_password_message)
           end
 
           login = param(login_param)
           unless login_meets_requirements?(login)
-            throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+            throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
           end
 
           if require_login_confirmation? && login != param(login_confirm_param)
-            throw_error_status(unmatched_field_error_status, login_param, logins_do_not_match_message)
+            throw_error_reason(:logins_do_not_match, unmatched_field_error_status, login_param, logins_do_not_match_message)
           end
 
           transaction do

--- a/lib/rodauth/features/change_login.rb
+++ b/lib/rodauth/features/change_login.rb
@@ -35,7 +35,7 @@ module Rodauth
 
           login = param(login_param)
           unless login_meets_requirements?(login)
-            throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+            throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
           end
 
           if require_login_confirmation? && login != param(login_confirm_param)
@@ -65,7 +65,7 @@ module Rodauth
 
     def change_login(login)
       if account_ds.get(login_column).downcase == login.downcase
-        @login_requirement_message = same_as_current_login_message
+        set_login_requirement_error_message(:same_as_current_login, same_as_current_login_message)
         return false
       end
 
@@ -82,7 +82,7 @@ module Rodauth
       updated = nil
       raised = raises_uniqueness_violation?{updated = update_account({login_column=>login}, account_ds.exclude(login_column=>login)) == 1}
       if raised
-        @login_requirement_message = already_an_account_with_this_login_message
+        set_login_requirement_error_message(:already_an_account_with_this_login, already_an_account_with_this_login_message)
       end
       updated && !raised
     end

--- a/lib/rodauth/features/change_password.rb
+++ b/lib/rodauth/features/change_password.rb
@@ -33,20 +33,20 @@ module Rodauth
       r.post do
         catch_error do
           if change_password_requires_password? && !password_match?(param(password_param))
-            throw_error_status(invalid_password_error_status, password_param, invalid_previous_password_message)
+            throw_error_reason(:invalid_previous_password, invalid_password_error_status, password_param, invalid_previous_password_message)
           end
 
           password = param(new_password_param)
           if require_password_confirmation? && password != param(password_confirm_param)
-            throw_error_status(unmatched_field_error_status, new_password_param, passwords_do_not_match_message)
+            throw_error_reason(:passwords_do_not_match, unmatched_field_error_status, new_password_param, passwords_do_not_match_message)
           end
 
           if password_match?(password) 
-            throw_error_status(invalid_field_error_status, new_password_param, same_as_existing_password_message)
+            throw_error_reason(:same_as_existing_password, invalid_field_error_status, new_password_param, same_as_existing_password_message)
           end
 
           unless password_meets_requirements?(password)
-            throw_error_status(invalid_field_error_status, new_password_param, password_does_not_meet_requirements_message)
+            throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, new_password_param, password_does_not_meet_requirements_message)
           end
 
           transaction do

--- a/lib/rodauth/features/change_password.rb
+++ b/lib/rodauth/features/change_password.rb
@@ -46,7 +46,7 @@ module Rodauth
           end
 
           unless password_meets_requirements?(password)
-            throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, new_password_param, password_does_not_meet_requirements_message)
+            throw_error_status(invalid_field_error_status, new_password_param, password_does_not_meet_requirements_message)
           end
 
           transaction do

--- a/lib/rodauth/features/close_account.rb
+++ b/lib/rodauth/features/close_account.rb
@@ -35,7 +35,7 @@ module Rodauth
       r.post do
         catch_error do
           if close_account_requires_password? && !password_match?(param(password_param))
-            throw_error_status(invalid_password_error_status, password_param, invalid_password_message)
+            throw_error_reason(:invalid_password, invalid_password_error_status, password_param, invalid_password_message)
           end
 
           transaction do

--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -40,7 +40,7 @@ module Rodauth
           set_notice_flash confirm_password_notice_flash
           redirect confirm_password_redirect
         else
-          set_response_error_status(invalid_password_error_status)
+          set_response_error_reason_status(:invalid_password, invalid_password_error_status)
           set_field_error(password_param, invalid_password_message)
           set_error_flash confirm_password_error_flash
           confirm_password_view
@@ -89,4 +89,3 @@ module Rodauth
     end
   end
 end
-

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -47,7 +47,7 @@ module Rodauth
           end
 
           unless login_meets_requirements?(login)
-            throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+            throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
           end
 
           if create_account_set_password?
@@ -67,7 +67,7 @@ module Rodauth
           transaction do
             before_create_account
             unless save_account
-              throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+              throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
             end
 
             if create_account_set_password? && !account_password_hash_column
@@ -100,7 +100,7 @@ module Rodauth
       raised = raises_uniqueness_violation?{id = db[accounts_table].insert(account)}
 
       if raised
-        @login_requirement_message = already_an_account_with_this_login_message
+        set_login_requirement_error_message(:already_an_account_with_this_login, already_an_account_with_this_login_message)
       end
 
       if id

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -43,20 +43,20 @@ module Rodauth
 
         catch_error do
           if require_login_confirmation? && login != param(login_confirm_param)
-            throw_error_status(unmatched_field_error_status, login_param, logins_do_not_match_message)
+            throw_error_reason(:logins_do_not_match, unmatched_field_error_status, login_param, logins_do_not_match_message)
           end
 
           unless login_meets_requirements?(login)
-            throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+            throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
           end
 
           if create_account_set_password?
             if require_password_confirmation? && password != param(password_confirm_param)
-              throw_error_status(unmatched_field_error_status, password_param, passwords_do_not_match_message)
+              throw_error_reason(:passwords_do_not_match, unmatched_field_error_status, password_param, passwords_do_not_match_message)
             end
 
             unless password_meets_requirements?(password)
-              throw_error_status(invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
+              throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
             end
 
             if account_password_hash_column
@@ -67,7 +67,7 @@ module Rodauth
           transaction do
             before_create_account
             unless save_account
-              throw_error_status(invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
+              throw_error_reason(:login_does_not_meet_requirements, invalid_field_error_status, login_param, login_does_not_meet_requirements_message)
             end
 
             if create_account_set_password? && !account_password_hash_column

--- a/lib/rodauth/features/disallow_common_passwords.rb
+++ b/lib/rodauth/features/disallow_common_passwords.rb
@@ -32,7 +32,7 @@ module Rodauth
 
     def password_not_one_of_the_most_common?(password)
       return true unless password_one_of_most_common?(password)
-      @password_requirement_message = password_is_one_of_the_most_common_message
+      set_password_requirement_error_message(:password_is_one_of_the_most_common, password_is_one_of_the_most_common_message)
       false
     end
   end

--- a/lib/rodauth/features/disallow_password_reuse.rb
+++ b/lib/rodauth/features/disallow_password_reuse.rb
@@ -65,7 +65,7 @@ module Rodauth
       end
 
       return true unless match
-      @password_requirement_message = password_same_as_previous_password_message
+      set_password_requirement_error_message(:password_same_as_previous_password,password_same_as_previous_password_message)
       false
     end
 

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -134,7 +134,7 @@ module Rodauth
           set_notice_flash unlock_account_notice_flash
           redirect unlock_account_redirect
         else
-          set_response_error_status(invalid_password_error_status)
+          set_response_error_reason_status(:invalid_password, invalid_password_error_status)
           set_field_error(password_param, invalid_password_message)
           set_error_flash unlock_account_error_flash
           unlock_account_view
@@ -271,7 +271,7 @@ module Rodauth
     end
 
     def show_lockout_page
-      set_response_error_status lockout_error_status
+      set_response_error_reason_status(:account_is_locked_out, lockout_error_status)
       set_error_flash login_lockout_error_flash
       response.write unlock_account_request_view
       request.halt

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -39,13 +39,13 @@ module Rodauth
 
         catch_error do
           unless account_from_login(param(login_param))
-            throw_error_status(no_matching_login_error_status, login_param, no_matching_login_message)
+            throw_error_reason(:no_matching_login, no_matching_login_error_status, login_param, no_matching_login_message)
           end
 
           before_login_attempt
 
           unless open_account?
-            throw_error_status(unopen_account_error_status, login_param, unverified_account_message)
+            throw_error_reason(:unopen_account, unopen_account_error_status, login_param, unverified_account_message)
           end
 
           if use_multi_phase_login?
@@ -61,7 +61,7 @@ module Rodauth
 
           unless password_match?(param(password_param))
             after_login_failure
-            throw_error_status(login_error_status, password_param, invalid_password_message)
+            throw_error_reason(:invalid_password, login_error_status, password_param, invalid_password_message)
           end
 
           login('password')

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -93,13 +93,18 @@ module Rodauth
     def login_too_short_message
       "minimum #{login_minimum_length} characters"
     end
+    
+    def set_login_requirement_error_message(reason, message)
+      set_error_reason(reason)
+      @login_requirement_message = message
+    end
 
     def login_meets_length_requirements?(login)
       if login_minimum_length > login.length
-        @login_requirement_message = login_too_short_message
+        set_login_requirement_error_message(:login_too_short, login_too_short_message)
         false
       elsif login_maximum_length < login.length
-        @login_requirement_message = login_too_long_message
+        set_login_requirement_error_message(:login_too_long, login_too_long_message)
         false
       else
         true
@@ -109,7 +114,7 @@ module Rodauth
     def login_meets_email_requirements?(login)
       return true unless require_email_address_logins?
       return true if login_valid_email?(login)
-      @login_requirement_message = login_not_valid_email_message
+      set_login_requirement_error_message(:login_not_valid_email, login_not_valid_email_message)
       return false
     end
 
@@ -150,4 +155,3 @@ module Rodauth
     end
   end
 end
-

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -81,6 +81,11 @@ module Rodauth
     def password_too_short_message
       "minimum #{password_minimum_length} characters"
     end
+    
+    def set_password_requirement_error_message(reason, message)
+      set_error_reason(reason)
+      @password_requirement_message = message
+    end
 
     def login_does_not_meet_requirements_message
       "invalid login#{", #{login_requirement_message}" if login_requirement_message}"
@@ -124,13 +129,13 @@ module Rodauth
 
     def password_meets_length_requirements?(password)
       return true if password_minimum_length <= password.length
-      @password_requirement_message = password_too_short_message
+      set_password_requirement_error_message(:password_too_short, password_too_short_message)
       false
     end
 
     def password_does_not_contain_null_byte?(password)
       return true unless password.include?("\0")
-      @password_requirement_message = contains_null_byte_message
+      set_password_requirement_error_message(:password_contains_null_byte, contains_null_byte_message)
       false
     end
 

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -123,6 +123,7 @@ module Rodauth
         otp_record_authentication_failure
         after_otp_authentication_failure
         set_response_error_status(invalid_key_error_status)
+        set_error_reason(:invalid_otp_auth_code)
         set_field_error(otp_auth_param, otp_invalid_auth_code_message)
         set_error_flash otp_auth_error_flash
         otp_auth_view
@@ -149,7 +150,7 @@ module Rodauth
         catch_error do
           unless otp_valid_key?(secret)
             otp_tmp_key(otp_new_secret)
-            throw_error_status(invalid_field_error_status, otp_setup_param, otp_invalid_secret_message)
+            throw_error_reason(:invalid_otp_secret, invalid_field_error_status, otp_setup_param, otp_invalid_secret_message)
           end
 
           if otp_keys_use_hmac?
@@ -159,11 +160,11 @@ module Rodauth
           end
 
           unless two_factor_password_match?(param(password_param))
-            throw_error_status(invalid_password_error_status, password_param, invalid_password_message)
+            throw_error_reason(:invalid_password, invalid_password_error_status, password_param, invalid_password_message)
           end
 
           unless otp_valid_code?(param(otp_auth_param))
-            throw_error_status(invalid_key_error_status, otp_auth_param, otp_invalid_auth_code_message)
+            throw_error_reason(:invalid_otp_auth_code, invalid_key_error_status, otp_auth_param, otp_invalid_auth_code_message)
           end
 
           transaction do

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -103,7 +103,7 @@ module Rodauth
       require_otp_setup
 
       if otp_locked_out?
-        set_response_error_status(lockout_error_status)
+        set_response_error_reason_status(:account_is_locked_out, lockout_error_status)
         set_redirect_error_flash otp_lockout_error_flash
         redirect otp_lockout_redirect
       end
@@ -122,7 +122,7 @@ module Rodauth
 
         otp_record_authentication_failure
         after_otp_authentication_failure
-        set_response_error_status(invalid_key_error_status)
+        set_response_error_reason_status(:invalid_otp_key, invalid_key_error_status)
         set_error_reason(:invalid_otp_auth_code)
         set_field_error(otp_auth_param, otp_invalid_auth_code_message)
         set_error_flash otp_auth_error_flash
@@ -207,7 +207,7 @@ module Rodauth
           redirect otp_disable_redirect
         end
 
-        set_response_error_status(invalid_password_error_status)
+        set_response_error_reason_status(:invalid_password, invalid_password_error_status)
         set_field_error(password_param, invalid_password_message)
         set_error_flash otp_disable_error_flash
         otp_disable_view

--- a/lib/rodauth/features/password_complexity.rb
+++ b/lib/rodauth/features/password_complexity.rb
@@ -54,21 +54,21 @@ module Rodauth
     def password_has_enough_character_groups?(password)
       return true if password.length > password_max_length_for_groups_check
       return true if password_character_groups.select{|re| password =~ re}.length >= password_min_groups
-      @password_requirement_message = password_not_enough_character_groups_message
+      set_password_requirement_error_message(:not_enough_character_groups_in_password, password_not_enough_character_groups_message)
       false
     end
 
     def password_has_no_invalid_pattern?(password)
       return true unless password_invalid_pattern
       return true if password !~ password_invalid_pattern
-      @password_requirement_message = password_invalid_pattern_message
+      set_password_requirement_error_message(:invalid_password_pattern, password_invalid_pattern_message)
       false
     end
 
     def password_not_too_many_repeating_characters?(password)
       return true if password_max_repeating_characters < 2
       return true if password !~ /(.)(\1){#{password_max_repeating_characters-1}}/ 
-      @password_requirement_message = password_too_many_repeating_characters_message
+      set_password_requirement_error_message(:too_many_reapeating_characters_in_password, password_too_many_repeating_characters_message)
       false
     end
 
@@ -77,7 +77,7 @@ module Rodauth
       return true unless password =~ /\A(?:\d*)([A-Za-z!@$+|][A-Za-z!@$+|0134578]+[A-Za-z!@$+|])(?:\d*)\z/
       word = $1.downcase.tr('!@$+|0134578', 'iastloleastb')
       return true if !dict.include?(word)
-      @password_requirement_message = password_in_dictionary_message
+      set_password_requirement_error_message(:password_in_dictionnary, password_in_dictionary_message)
       false
     end
   end

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -76,7 +76,7 @@ module Rodauth
           two_factor_authenticate('recovery_code')
         end
 
-        set_response_error_status(invalid_key_error_status)
+        set_response_error_reason_status(:invalid_recovery_code, invalid_key_error_status)
         set_field_error(recovery_codes_param, invalid_recovery_code_message)
         set_error_flash invalid_recovery_code_error_flash
         recovery_auth_view
@@ -119,7 +119,7 @@ module Rodauth
             set_error_flash view_recovery_codes_error_flash
           end
 
-          set_response_error_status(invalid_password_error_status)
+          set_response_error_reason_status(:invalid_password, invalid_password_error_status)
           set_field_error(password_param, invalid_password_message)
           recovery_codes_view
         end

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -74,7 +74,7 @@ module Rodauth
           set_notice_flash remember_notice_flash
           redirect remember_redirect
         else
-          set_response_error_status(invalid_field_error_status)
+          set_response_error_reason_status(:invalid_remember_param, invalid_field_error_status)
           set_error_flash remember_error_flash
           remember_view
         end

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -138,7 +138,7 @@ module Rodauth
           end
 
           unless password_meets_requirements?(password)
-            throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
+            throw_error_status(invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
           end
 
           transaction do

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -68,11 +68,11 @@ module Rodauth
       r.post do
         catch_error do
           unless account_from_login(param(login_param))
-            throw_error_status(no_matching_login_error_status, login_param, no_matching_login_message)
+            throw_error_reason(:no_matching_login, no_matching_login_error_status, login_param, no_matching_login_message)
           end
 
           unless open_account?
-            throw_error_status(unopen_account_error_status, login_param, unverified_account_message)
+            throw_error_reason(:unverified_account, unopen_account_error_status, login_param, unverified_account_message)
           end
 
           if reset_password_email_recently_sent?
@@ -130,15 +130,15 @@ module Rodauth
         password = param(password_param)
         catch_error do
           if password_match?(password) 
-            throw_error_status(invalid_field_error_status, password_param, same_as_existing_password_message)
+            throw_error_reason(:same_as_existing_password, invalid_field_error_status, password_param, same_as_existing_password_message)
           end
 
           if require_password_confirmation? && password != param(password_confirm_param)
-            throw_error_status(unmatched_field_error_status, password_param, passwords_do_not_match_message)
+            throw_error_reason(:passwords_do_not_match, unmatched_field_error_status, password_param, passwords_do_not_match_message)
           end
 
           unless password_meets_requirements?(password)
-            throw_error_status(invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
+            throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
           end
 
           transaction do

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -146,7 +146,7 @@ module Rodauth
           sms_set_code(nil)
         end
 
-        set_response_error_status(invalid_key_error_status)
+        set_response_error_reason_status(:no_current_sms_code, invalid_key_error_status)
         set_redirect_error_flash no_current_sms_code_error_flash
         redirect sms_request_redirect
       end
@@ -169,7 +169,7 @@ module Rodauth
           end
         end
 
-        set_response_error_status(invalid_key_error_status)
+        set_response_error_reason_status(:invalid_sms_code, invalid_key_error_status)
         set_field_error(sms_code_param, sms_invalid_code_message)
         set_error_flash sms_invalid_code_error_flash
         sms_auth_view
@@ -282,7 +282,7 @@ module Rodauth
           redirect sms_disable_redirect
         end
 
-        set_response_error_status(invalid_password_error_status)
+        set_response_error_reason_status(:invalid_password, invalid_password_error_status)
         set_field_error(password_param, invalid_password_message)
         set_error_flash sms_disable_error_flash
         sms_disable_view

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -199,13 +199,13 @@ module Rodauth
       r.post do
         catch_error do
           unless two_factor_password_match?(param(password_param))
-            throw_error_status(invalid_password_error_status, password_param, invalid_password_message)
+            throw_error_reason(:invalid_password, invalid_password_error_status, password_param, invalid_password_message)
           end
 
           phone = sms_normalize_phone(param(sms_phone_param))
 
           unless sms_valid_phone?(phone)
-            throw_error_status(invalid_field_error_status, sms_phone_param, sms_invalid_phone_message)
+            throw_error_reason(:invalid_phone_number, invalid_field_error_status, sms_phone_param, sms_invalid_phone_message)
           end
 
           transaction do

--- a/lib/rodauth/features/two_factor_base.rb
+++ b/lib/rodauth/features/two_factor_base.rb
@@ -106,7 +106,7 @@ module Rodauth
           redirect two_factor_disable_redirect
         end
 
-        set_response_error_status(invalid_password_error_status)
+        set_response_error_reason_status(:invalid_password, invalid_password_error_status)
         set_field_error(password_param, invalid_password_message)
         set_error_flash two_factor_disable_error_flash
         two_factor_disable_view

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -133,7 +133,7 @@ module Rodauth
             end
 
             unless password_meets_requirements?(password)
-              throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
+              throw_error_status(invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
             end
           end
 

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -129,11 +129,11 @@ module Rodauth
             password = param(password_param)
 
             if require_password_confirmation? && password != param(password_confirm_param)
-              throw_error_status(unmatched_field_error_status, password_param, passwords_do_not_match_message)
+              throw_error_reason(:passwords_do_not_match, unmatched_field_error_status, password_param, passwords_do_not_match_message)
             end
 
             unless password_meets_requirements?(password)
-              throw_error_status(invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
+              throw_error_reason(:password_does_not_meet_requirements, invalid_field_error_status, password_param, password_does_not_meet_requirements_message)
             end
           end
 

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -151,7 +151,7 @@ module Rodauth
 
     def update_login(login)
       if _account_from_login(login)
-        @login_requirement_message = already_an_account_with_this_login_message
+        set_login_requirement_error_message(:already_an_account_with_this_login, already_an_account_with_this_login_message)
         return false
       end
 
@@ -213,4 +213,3 @@ module Rodauth
     end
   end
 end
-

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -17,7 +17,7 @@ module Rodauth
       r.post do
         catch_error do
           unless account_from_login(param(login_param)) && open_account?
-            throw_error_status(no_matching_login_error_status, login_param, no_matching_login_message) 
+            throw_error_reason(:no_matching_login, no_matching_login_error_status, login_param, no_matching_login_message) 
           end
 
           webauthn_credential = webauthn_auth_credential_from_form_submission

--- a/spec/change_login_spec.rb
+++ b/spec/change_login_spec.rb
@@ -137,13 +137,19 @@ describe 'Rodauth change_login feature' do
       json_login
 
       res = json_request('/change-login', :login=>'foobar', "login-confirm"=>'foobar')
-      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, not a valid email address"]}]
+      res.must_equal [422, {'reason'=>"login_not_valid_email",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, not a valid email address"]}]
 
       res = json_request('/change-login', :login=>'foo@example.com', "login-confirm"=>'foo2@example.com')
       res.must_equal [422, {'reason'=>"logins_do_not_match",'error'=>"There was an error changing your login", "field-error"=>["login", "logins do not match"]}]
 
       res = json_request('/change-login', :login=>'foo2@example.com', "login-confirm"=>'foo2@example.com')
-      res.must_equal [422, {'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, already an account with this login"]}]
+      res.must_equal [422, {'reason'=>"already_an_account_with_this_login",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, already an account with this login"]}]
+    
+      res = json_request('/change-login', :login=>'f', "login-confirm"=>'f')
+      res.must_equal [422, {'reason'=>"login_too_short",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, minimum 3 characters"]}]
+      
+      res = json_request('/change-login', :login=>'f'*256, "login-confirm"=>'f'*256)
+      res.must_equal [422, {'reason'=>"login_too_long",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, maximum 255 characters"]}]
 
       res = json_request('/change-login', :login=>'foo3@example.com', "login-confirm"=>'foo3@example.com')
       res.must_equal [200, {'success'=>"Your login has been changed"}]

--- a/spec/change_login_spec.rb
+++ b/spec/change_login_spec.rb
@@ -137,10 +137,10 @@ describe 'Rodauth change_login feature' do
       json_login
 
       res = json_request('/change-login', :login=>'foobar', "login-confirm"=>'foobar')
-      res.must_equal [422, {'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, not a valid email address"]}]
+      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, not a valid email address"]}]
 
       res = json_request('/change-login', :login=>'foo@example.com', "login-confirm"=>'foo2@example.com')
-      res.must_equal [422, {'error'=>"There was an error changing your login", "field-error"=>["login", "logins do not match"]}]
+      res.must_equal [422, {'reason'=>"logins_do_not_match",'error'=>"There was an error changing your login", "field-error"=>["login", "logins do not match"]}]
 
       res = json_request('/change-login', :login=>'foo2@example.com', "login-confirm"=>'foo2@example.com')
       res.must_equal [422, {'error'=>"There was an error changing your login", "field-error"=>["login", "invalid login, already an account with this login"]}]
@@ -154,7 +154,7 @@ describe 'Rodauth change_login feature' do
       require_password = true
 
       res = json_request('/change-login', :login=>'foo4@example.com', "login-confirm"=>'foo4@example.com', :password=>'012345678')
-      res.must_equal [401, {'error'=>"There was an error changing your login", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error changing your login", "field-error"=>["password", "invalid password"]}]
 
       res = json_request('/change-login', :login=>'foo4@example.com', "login-confirm"=>'foo4@example.com', :password=>'0123456789')
       res.must_equal [200, {'success'=>"Your login has been changed"}]

--- a/spec/change_password_spec.rb
+++ b/spec/change_password_spec.rb
@@ -175,20 +175,20 @@ describe 'Rodauth change_password feature' do
       json_login
 
       res = json_request('/change-password', :password=>'0123456789', "new-password"=>'0123456', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error changing your password", "field-error"=>["new-password", "passwords do not match"]}]
+      res.must_equal [422, {'reason'=>"passwords_do_not_match",'error'=>"There was an error changing your password", "field-error"=>["new-password", "passwords do not match"]}]
 
       res = json_request('/change-password', :password=>'0123456', "new-password"=>'0123456', "password-confirm"=>'0123456')
-      res.must_equal [401, {'error'=>"There was an error changing your password", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_previous_password",'error'=>"There was an error changing your password", "field-error"=>["password", "invalid password"]}]
 
       res = json_request('/change-password', :password=>'0123456789', "new-password"=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error changing your password", "field-error"=>["new-password", "invalid password, same as current password"]}]
+      res.must_equal [422, {'reason'=>"same_as_existing_password",'error'=>"There was an error changing your password", "field-error"=>["new-password", "invalid password, same as current password"]}]
 
       res = json_request('/change-password', :password=>'0123456789', "new-password"=>'0123456', "password-confirm"=>'0123456')
       res.must_equal [200, {'success'=>"Your password has been changed"}]
 
       json_logout
       res = json_login(:no_check=>true)
-      res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
 
       json_login(:pass=>'0123456')
 

--- a/spec/close_account_spec.rb
+++ b/spec/close_account_spec.rb
@@ -153,7 +153,7 @@ describe 'Rodauth close_account feature' do
       json_login
 
       res = json_request('/close-account', :password=>'0123456')
-      res.must_equal [401, {'error'=>"There was an error closing your account", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error closing your account", "field-error"=>["password", "invalid password"]}]
       DB[:accounts].select_map(:status_id).must_equal [2]
 
       res = json_request('/close-account', :password=>'0123456789')

--- a/spec/confirm_password_spec.rb
+++ b/spec/confirm_password_spec.rb
@@ -164,7 +164,7 @@ describe 'Rodauth confirm password feature' do
       json_request('/reset').must_equal [200, [1]]
 
       res = json_request('/change-password', "new-password"=>'01234567', "password-confirm"=>'01234567')
-      res.must_equal [401, {"field-error"=>["password", "invalid password"], "error"=>"There was an error changing your password"}]
+      res.must_equal [401, {'reason'=>"invalid_previous_password","field-error"=>["password", "invalid password"], "error"=>"There was an error changing your password"}]
 
       res = json_request('/confirm-password', "password"=>'0123456')
       res.must_equal [200, {'success'=>"Your password has been confirmed"}]

--- a/spec/create_account_spec.rb
+++ b/spec/create_account_spec.rb
@@ -111,10 +111,16 @@ describe 'Rodauth create_account feature' do
       end
 
       res = json_request('/create-account', :login=>'foo@example.com', "login-confirm"=>'foo@example.com', :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, already an account with this login"]}]
+      res.must_equal [422, {'reason'=>"already_an_account_with_this_login",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, already an account with this login"]}]
+            
+      res = json_request('/create-account', :login=>'f', "login-confirm"=>'f', :password=>'0123456789', "password-confirm"=>'0123456789')
+      res.must_equal [422, {'reason'=>"login_too_short",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, minimum 3 characters"]}]
+      
+      res = json_request('/create-account', :login=>'f'*256, "login-confirm"=>'f'*256, :password=>'0123456789', "password-confirm"=>'0123456789')
+      res.must_equal [422, {'reason'=>"login_too_long",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, maximum 255 characters"]}]
 
       res = json_request('/create-account', :login=>'foobar', "login-confirm"=>'foobar', :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, not a valid email address"]}]
+      res.must_equal [422, {'reason'=>"login_not_valid_email",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, not a valid email address"]}]
 
       res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foobar', :password=>'0123456789', "password-confirm"=>'0123456789')
       res.must_equal [422, {'reason'=>"logins_do_not_match",'error'=>"There was an error creating your account", "field-error"=>["login", "logins do not match"]}]

--- a/spec/create_account_spec.rb
+++ b/spec/create_account_spec.rb
@@ -111,16 +111,16 @@ describe 'Rodauth create_account feature' do
       end
 
       res = json_request('/create-account', :login=>'foo@example.com', "login-confirm"=>'foo@example.com', :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, already an account with this login"]}]
+      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, already an account with this login"]}]
 
       res = json_request('/create-account', :login=>'foobar', "login-confirm"=>'foobar', :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, not a valid email address"]}]
+      res.must_equal [422, {'reason'=>"login_does_not_meet_requirements",'error'=>"There was an error creating your account", "field-error"=>["login", "invalid login, not a valid email address"]}]
 
       res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foobar', :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error creating your account", "field-error"=>["login", "logins do not match"]}]
+      res.must_equal [422, {'reason'=>"logins_do_not_match",'error'=>"There was an error creating your account", "field-error"=>["login", "logins do not match"]}]
 
       res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foo@example2.com', :password=>'012345678', "password-confirm"=>'0123456789')
-      res.must_equal [422, {'error'=>"There was an error creating your account", "field-error"=>["password", "passwords do not match"]}]
+      res.must_equal [422, {'reason'=>"passwords_do_not_match",'error'=>"There was an error creating your account", "field-error"=>["password", "passwords do not match"]}]
 
       res = json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
       res.must_equal [200, {'success'=>"Your account has been created", 'account_id'=>DB[:accounts].where(:email=>'foo@example2.com').get(:id)}]

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -325,7 +325,7 @@ describe 'Rodauth login feature' do
     json_request('/create-account', :login=>'foo@example2.com', "login-confirm"=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
 
     res = json_request('/login', :login=>'foo@example2.com', :password=>'123123')
-    res.must_equal [401, {"field-error"=>['password', 'invalid password'], "error"=>"There was an error logging in"}]
+    res.must_equal [401, {'reason'=>"invalid_password","field-error"=>['password', 'invalid password'], "error"=>"There was an error logging in"}]
   end
 
   it "should not allow refreshing token without providing access token" do

--- a/spec/lockout_spec.rb
+++ b/spec/lockout_spec.rb
@@ -257,7 +257,7 @@ describe 'Rodauth lockout feature' do
 
       2.times do
         res = json_login(:pass=>'1', :no_check=>true)
-        res.must_equal [403, {'error'=>"This account is currently locked out and cannot be logged in to"}]
+        res.must_equal [403, {'reason'=>"account_is_locked_out", 'error'=>"This account is currently locked out and cannot be logged in to"}]
       end
 
       res = json_request('/unlock-account')

--- a/spec/lockout_spec.rb
+++ b/spec/lockout_spec.rb
@@ -245,14 +245,14 @@ describe 'Rodauth lockout feature' do
       res.must_equal [401, {'error'=>"No matching login"}]
 
       res = json_login(:pass=>'1', :no_check=>true)
-      res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
 
       json_login
       json_logout
 
       2.times do
         res = json_login(:pass=>'1', :no_check=>true)
-        res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
+        res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
       end
 
       2.times do

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -391,10 +391,10 @@ describe 'Rodauth login feature' do
     json_request.must_equal [200, 2]
 
     res = json_request("/login", :login=>'foo@example2.com', :password=>'0123456789')
-    res.must_equal [400, {'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
+    res.must_equal [400, {'reason'=>"no_matching_login",'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
 
     res = json_request("/login", :login=>'foo@example.com', :password=>'012345678')
-    res.must_equal [400, {'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
+    res.must_equal [400, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
 
     json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
     json_request.must_equal [200, 1]
@@ -424,10 +424,10 @@ describe 'Rodauth login feature' do
       res.must_equal [401, {"error"=>"Please login to continue"}]
 
       res = json_request("/login", :login=>'foo@example2.com', :password=>'0123456789')
-      res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
+      res.must_equal [401, {'reason'=>"no_matching_login",'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
 
       res = json_request("/login", :login=>'foo@example.com', :password=>'012345678')
-      res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
 
       json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
       json_request.must_equal [200, 1]

--- a/spec/remember_spec.rb
+++ b/spec/remember_spec.rb
@@ -534,7 +534,7 @@ describe 'Rodauth remember feature' do
       json_request.must_equal [200, [1]]
 
       res = json_request('/confirm-password', :password=>'123456')
-      res.must_equal [401, {'error'=>"There was an error confirming your password", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {'reason'=>"invalid_password", 'error'=>"There was an error confirming your password", "field-error"=>["password", "invalid password"]}]
 
       res = json_request('/confirm-password', :password=>'0123456789')
       res.must_equal [200, {'success'=>"Your password has been confirmed"}]

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -278,10 +278,10 @@ describe 'Rodauth reset_password feature' do
       res.must_equal [422, {'reason'=>"same_as_existing_password","error"=>"There was an error resetting your password", "field-error"=>["password", 'invalid password, same as current password']}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'1', "password-confirm"=>'1')
-      res.must_equal [422, {'reason'=>"password_does_not_meet_requirements","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (minimum 6 characters)"]}]
+      res.must_equal [422, {'reason'=>"password_too_short","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (minimum 6 characters)"]}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>"\0ab123456", "password-confirm"=>"\0ab123456")
-      res.must_equal [422, {'reason'=>"password_does_not_meet_requirements","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (contains null byte)"]}]
+      res.must_equal [422, {'reason'=>"password_contains_null_byte","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (contains null byte)"]}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'0123456', "password-confirm"=>'0123456')
       res.must_equal [200, {"success"=>"Your password has been reset"}]

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -256,13 +256,13 @@ describe 'Rodauth reset_password feature' do
       end
 
       res = json_login(:pass=>'1', :no_check=>true)
-      res.must_equal [401, {"field-error"=>["password", "invalid password"], "error"=>"There was an error logging in"}]
+      res.must_equal [401, {'reason'=>"invalid_password","field-error"=>["password", "invalid password"], "error"=>"There was an error logging in"}]
 
       res = json_request('/reset-password')
       res.must_equal [401, {"error"=>"There was an error resetting your password"}]
 
       res = json_request('/reset-password-request', :login=>'foo@example2.com')
-      res.must_equal [401, {"field-error"=>["login", "no matching login"], "error"=>"There was an error requesting a password reset"}]
+      res.must_equal [401, {'reason'=>"no_matching_login","field-error"=>["login", "no matching login"], "error"=>"There was an error requesting a password reset"}]
 
       res = json_request('/reset-password-request', :login=>'foo@example.com')
       res.must_equal [200, {"success"=>"An email has been sent to you with a link to reset the password for your account"}]
@@ -272,16 +272,16 @@ describe 'Rodauth reset_password feature' do
       res.must_equal [401, {"error"=>"There was an error resetting your password"}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'1', "password-confirm"=>'2')
-      res.must_equal [422, {"error"=>"There was an error resetting your password", "field-error"=>["password", 'passwords do not match']}]
+      res.must_equal [422, {'reason'=>"passwords_do_not_match","error"=>"There was an error resetting your password", "field-error"=>["password", 'passwords do not match']}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'0123456789', "password-confirm"=>'0123456789')
-      res.must_equal [422, {"error"=>"There was an error resetting your password", "field-error"=>["password", 'invalid password, same as current password']}]
+      res.must_equal [422, {'reason'=>"same_as_existing_password","error"=>"There was an error resetting your password", "field-error"=>["password", 'invalid password, same as current password']}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'1', "password-confirm"=>'1')
-      res.must_equal [422, {"error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (minimum 6 characters)"]}]
+      res.must_equal [422, {'reason'=>"password_does_not_meet_requirements","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (minimum 6 characters)"]}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>"\0ab123456", "password-confirm"=>"\0ab123456")
-      res.must_equal [422, {"error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (contains null byte)"]}]
+      res.must_equal [422, {'reason'=>"password_does_not_meet_requirements","error"=>"There was an error resetting your password", "field-error"=>["password", "invalid password, does not meet requirements (contains null byte)"]}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'0123456', "password-confirm"=>'0123456')
       res.must_equal [200, {"success"=>"Your password has been reset"}]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -271,6 +271,9 @@ class Minitest::HooksSpec
         enable :json
         only_json? true if json_only
       end
+      if jwt_enable || json_enable
+        set_error_reason { |reason| json_response['reason'] = reason }
+      end
       if ENV['RODAUTH_SEPARATE_SCHEMA']
         password_hash_table Sequel[:rodauth_test_password][:account_password_hashes]
         function_name do |name|

--- a/spec/two_factor_spec.rb
+++ b/spec/two_factor_spec.rb
@@ -1292,13 +1292,13 @@ describe 'Rodauth OTP feature' do
       totp = ROTP::TOTP.new(secret)
 
       res = json_request('/otp-setup', :password=>'123456', :otp_secret=>secret)
-      res.must_equal [401, {'error'=>'Error setting up TOTP authentication', "field-error"=>["password", 'invalid password']}] 
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>'Error setting up TOTP authentication', "field-error"=>["password", 'invalid password']}] 
 
       res = json_request('/otp-setup', :password=>'0123456789', :otp=>'adsf', :otp_secret=>secret)
-      res.must_equal [401, {'error'=>'Error setting up TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
+      res.must_equal [401, {'reason'=>"invalid_otp_auth_code",'error'=>'Error setting up TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
 
       res = json_request('/otp-setup', :password=>'0123456789', :otp=>'adsf', :otp_secret=>'asdf')
-      res.must_equal [422, {'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
+      res.must_equal [422, {'reason'=>"invalid_otp_secret",'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
 
       res = json_request('/otp-setup', :password=>'0123456789', :otp=>totp.now, :otp_secret=>secret)
       res.must_equal [200, {'success'=>'TOTP authentication is now setup'}]
@@ -1313,7 +1313,7 @@ describe 'Rodauth OTP feature' do
       end
 
       res = json_request('/otp-auth', :otp=>'adsf')
-      res.must_equal [401, {'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
+      res.must_equal [401, {'reason'=>"invalid_otp_auth_code",'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
 
       res = json_request('/otp-auth', :otp=>totp.now)
       res.must_equal [200, {'success'=>'You have been multifactor authenticated'}]
@@ -1332,10 +1332,10 @@ describe 'Rodauth OTP feature' do
       res.must_equal [403, {'error'=>'SMS authentication has not been setup yet'}] 
 
       res = json_request('/sms-setup', :password=>'012345678', "sms-phone"=>'(123) 456')
-      res.must_equal [401, {'error'=>'Error setting up SMS authentication', "field-error"=>["password", 'invalid password']}] 
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>'Error setting up SMS authentication', "field-error"=>["password", 'invalid password']}] 
 
       res = json_request('/sms-setup', :password=>'0123456789', "sms-phone"=>'(123) 456')
-      res.must_equal [422, {'error'=>'Error setting up SMS authentication', "field-error"=>["sms-phone", 'invalid SMS phone number']}] 
+      res.must_equal [422, {'reason'=>"invalid_phone_number",'error'=>'Error setting up SMS authentication', "field-error"=>["sms-phone", 'invalid SMS phone number']}] 
 
       res = json_request('/sms-setup', :password=>'0123456789', "sms-phone"=>'(123) 4567 890')
       res.must_equal [200, {'success'=>'SMS authentication needs confirmation'}]
@@ -1441,7 +1441,7 @@ describe 'Rodauth OTP feature' do
 
       5.times do
         res = json_request('/otp-auth', :otp=>'asdf')
-        res.must_equal [401, {'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
+        res.must_equal [401, {'reason'=>"invalid_otp_auth_code",'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
       end
 
       res = json_request('/otp-auth', :otp=>'asdf')
@@ -1491,12 +1491,12 @@ describe 'Rodauth OTP feature' do
       res = json_request('/otp-setup')
       secret = res[1].delete("otp_secret")
       raw_secret = res[1].delete("otp_raw_secret")
-      res.must_equal [422, {'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
+      res.must_equal [422, {'reason'=>"invalid_otp_secret",'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
 
       totp = ROTP::TOTP.new(secret)
       hmac_secret  = "321"
       res = json_request('/otp-setup', :password=>'0123456789', :otp=>totp.now, :otp_secret=>secret, :otp_raw_secret=>raw_secret)
-      res.must_equal [422, {'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
+      res.must_equal [422, {'reason'=>"invalid_otp_secret",'error'=>'Error setting up TOTP authentication', "field-error"=>["otp_secret", 'invalid secret']}] 
 
       reset_otp_last_use
       hmac_secret  = "123"
@@ -1509,7 +1509,7 @@ describe 'Rodauth OTP feature' do
 
       hmac_secret  = "321"
       res = json_request('/otp-auth', :otp=>totp.now)
-      res.must_equal [401, {'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
+      res.must_equal [401, {'reason'=>"invalid_otp_auth_code",'error'=>'Error logging in via TOTP authentication', "field-error"=>["otp", 'Invalid authentication code']}] 
 
       hmac_secret  = "123"
       res = json_request('/otp-auth', :otp=>totp.now)

--- a/spec/verify_login_change_spec.rb
+++ b/spec/verify_login_change_spec.rb
@@ -227,7 +227,7 @@ describe 'Rodauth verify_login_change feature' do
       res.must_equal [200, {"success"=>"Your login change has been verified"}]
 
       res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789')
-      res.must_equal [401, {'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
+      res.must_equal [401, {'reason'=>"no_matching_login",'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]
 
       json_login(:login=>'foo3@example.com')
     end

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -460,16 +460,16 @@ describe 'Rodauth webauthn feature' do
       setup_json = res[1].delete("webauthn_setup")
       challenge = res[1].delete("webauthn_setup_challenge")
       challenge_hmac = res[1].delete("webauthn_setup_challenge_hmac")
-      res.must_equal [422, {'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
+      res.must_equal [422, {'reason'=>"invalid_webauthn_setup_param",'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
 
       res = json_request('/webauthn-setup', :password=>'123456', :webauthn_setup=>'{}')
-      res.must_equal [401, {'error'=>'Error setting up WebAuthn authentication', "field-error"=>["password", 'invalid password']}] 
+      res.must_equal [401, {'reason'=>"invalid_password",'error'=>'Error setting up WebAuthn authentication', "field-error"=>["password", 'invalid password']}] 
 
       res = json_request('/webauthn-setup', :password=>'0123456789', :webauthn_setup=>bad_client.create(challenge: setup_json['challenge']), :webauthn_setup_challenge=>challenge+'1', :webauthn_setup_challenge_hmac=>challenge_hmac)
-      res.must_equal [422, {'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
+      res.must_equal [422, {'reason'=>"invalid_webauthn_setup_param",'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
 
       res = json_request('/webauthn-setup', :password=>'0123456789', :webauthn_setup=>bad_client.create(challenge: setup_json['challenge'] + '1'), :webauthn_setup_challenge=>challenge, :webauthn_setup_challenge_hmac=>challenge_hmac)
-      res.must_equal [422, {'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
+      res.must_equal [422, {'reason'=>"invalid_webauthn_setup_param",'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
 
       webauthn_hash1 = webauthn_client1.create(challenge: setup_json['challenge'])
       res = json_request('/webauthn-setup', :password=>'0123456789', :webauthn_setup=>webauthn_hash1, :webauthn_setup_challenge=>challenge, :webauthn_setup_challenge_hmac=>challenge_hmac)
@@ -479,7 +479,7 @@ describe 'Rodauth webauthn feature' do
       setup_json = res[1].delete("webauthn_setup")
       challenge = res[1].delete("webauthn_setup_challenge")
       challenge_hmac = res[1].delete("webauthn_setup_challenge_hmac")
-      res.must_equal [422, {'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
+      res.must_equal [422, {'reason'=>"invalid_webauthn_setup_param",'error'=>'Error setting up WebAuthn authentication', "field-error"=>["webauthn_setup", 'invalid webauthn setup param']}] 
 
       webauthn_hash2 = webauthn_client2.create(challenge: setup_json['challenge'])
       res = json_request('/webauthn-setup', :password=>'0123456789', :webauthn_setup=>webauthn_hash2, :webauthn_setup_challenge=>challenge, :webauthn_setup_challenge_hmac=>challenge_hmac)
@@ -494,7 +494,7 @@ describe 'Rodauth webauthn feature' do
       auth_json = res[1].delete("webauthn_auth")
       challenge = res[1].delete("webauthn_auth_challenge")
       challenge_hmac = res[1].delete("webauthn_auth_challenge_hmac")
-      res.must_equal [422, {"field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"Error authenticating using WebAuthn"}]
+      res.must_equal [422, {'reason'=>"invalid_webauthn_auth_param","field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"Error authenticating using WebAuthn"}]
 
       res = json_request('/webauthn-auth', :webauthn_auth=>webauthn_client1.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
       res.must_equal [200, {'success'=>'You have been multifactor authenticated'}]
@@ -507,7 +507,7 @@ describe 'Rodauth webauthn feature' do
       auth_json = res[1].delete("webauthn_auth")
       challenge = res[1].delete("webauthn_auth_challenge")
       challenge_hmac = res[1].delete("webauthn_auth_challenge_hmac")
-      res.must_equal [422, {"field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"Error authenticating using WebAuthn"}]
+      res.must_equal [422, {'reason'=>"invalid_webauthn_auth_param","field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"Error authenticating using WebAuthn"}]
 
       res = json_request('/webauthn-auth', :webauthn_auth=>webauthn_client2.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
       res.must_equal [200, {'success'=>'You have been multifactor authenticated'}]
@@ -518,11 +518,11 @@ describe 'Rodauth webauthn feature' do
       remove_ids[webauthn_hash1['rawId']].must_include(Time.now.strftime('%F'))
       remove_ids[webauthn_hash2['rawId']].must_include(Time.now.strftime('%F'))
       remove_ids.length.must_equal 2
-      res.must_equal [422, {"field-error"=>["webauthn_remove", "must select valid webauthn authenticator to remove"], "error"=>"Error removing WebAuthn authenticator"}]
+      res.must_equal [422, {'reason'=>"invalid_webauthn_remove_param","field-error"=>["webauthn_remove", "must select valid webauthn authenticator to remove"], "error"=>"Error removing WebAuthn authenticator"}]
 
       res = json_request('/webauthn-remove', :password=>'012345678', :webauthn_remove=>'1')
       res[1].delete("webauthn_remove").must_be_nil
-      res.must_equal [401, {"field-error"=>["password", "invalid password"], "error"=>"Error removing WebAuthn authenticator"}]
+      res.must_equal [401, {'reason'=>"invalid_password","field-error"=>["password", "invalid password"], "error"=>"Error removing WebAuthn authenticator"}]
 
       res = json_request('/webauthn-remove', :password=>'0123456789', :webauthn_remove=>webauthn_hash1['rawId'])
       res.must_equal [200, {'success'=>'WebAuthn authenticator has been removed'}]

--- a/spec/webauthn_verify_account_spec.rb
+++ b/spec/webauthn_verify_account_spec.rb
@@ -147,7 +147,7 @@ describe 'Rodauth webauthn_verify_account feature' do
       setup_json = res[1].delete("webauthn_setup")
       challenge = res[1].delete("webauthn_setup_challenge")
       challenge_hmac = res[1].delete("webauthn_setup_challenge_hmac")
-      res.must_equal [422, {"field-error"=>["webauthn_setup", "invalid webauthn setup param"], "error"=>"Unable to verify account"}]
+      res.must_equal [422, {'reason'=>"invalid_webauthn_setup_param","field-error"=>["webauthn_setup", "invalid webauthn setup param"], "error"=>"Unable to verify account"}]
 
       res = json_request('/verify-account', :key=>link[4..-1], :webauthn_setup=>webauthn_client.create(challenge: setup_json['challenge']), :webauthn_setup_challenge=>challenge, :webauthn_setup_challenge_hmac=>challenge_hmac)
       res.must_equal [200, {"success"=>"Your account has been verified"}]
@@ -156,7 +156,7 @@ describe 'Rodauth webauthn_verify_account feature' do
       auth_json = res[1].delete("webauthn_auth")
       challenge = res[1].delete("webauthn_auth_challenge")
       challenge_hmac = res[1].delete("webauthn_auth_challenge_hmac")
-      res.must_equal [422, {"field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"There was an error authenticating via WebAuthn"}]
+      res.must_equal [422, {'reason'=>"invalid_webauthn_auth_param","field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"There was an error authenticating via WebAuthn"}]
 
       res = json_request('/webauthn-login', :login=>'foo@example2.com', :webauthn_auth=>webauthn_client.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
       res.must_equal [200, {'success'=>'You have been logged in'}]


### PR DESCRIPTION
For example, this allows you to add this code to the JSON response so your app can display a custom screen or message when certain kinds of errors happen.

I updated every `throw_error_status` and `set_response_error_status` to set the reason code, with special handling for the login and password requirements.

The error reason code is added to the JSON response in `spec_helper.rb` so we can match it in tests.
Tests are passing locally using PostgreSQL.