### PR TITLE
More set_error_reason support

### DIFF
--- a/doc/error_reasons.rdoc
+++ b/doc/error_reasons.rdoc
@@ -19,7 +19,9 @@ Rodauth will call +set_error_reason+ with:
 
 * :account_locked_out
 * :already_an_account_with_this_login
+* :already_an_unopen_account_with_this_login
 * :duplicate_webauthn_id
+* :inactive_session
 * :invalid_otp_auth_code
 * :invalid_otp_secret
 * :invalid_password
@@ -28,7 +30,11 @@ Rodauth will call +set_error_reason+ with:
 * :invalid_previous_password
 * :invalid_recovery_code
 * :invalid_remember_param
+* :invalid_reset_password_key
 * :invalid_sms_code
+* :invalid_sms_confirmation_code
+* :invalid_verify_account_key
+* :invalid_unlock_account_key
 * :invalid_webauthn_auth_param
 * :invalid_webauthn_remove_param
 * :invalid_webauthn_setup_param
@@ -41,6 +47,7 @@ Rodauth will call +set_error_reason+ with:
 * :no_matching_login
 * :not_enough_character_groups_in_password
 * :otp_locked_out
+* :password_authentication_required
 * :password_contains_null_byte
 * :password_does_not_meet_requirements
 * :password_in_dictionary
@@ -50,5 +57,13 @@ Rodauth will call +set_error_reason+ with:
 * :passwords_do_not_match
 * :same_as_current_login
 * :same_as_existing_password
+* :session_expired
+* :sms_already_setup
+* :sms_locked_out
+* :sms_needs_confirmation
 * :too_many_repeating_characters_in_password
+* :two_factor_already_authenticated
+* :two_factor_need_authentication
+* :two_factor_not_setup
 * :unverified_account
+* :webauthn_not_setup

--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -57,6 +57,7 @@ module Rodauth
     def no_longer_active_session
       clear_session
       set_redirect_error_status inactive_session_error_status
+      set_error_reason :inactive_session
       set_redirect_error_flash active_sessions_error_flash
       redirect active_sessions_redirect
     end
@@ -176,4 +177,3 @@ module Rodauth
     end
   end
 end
-

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -295,6 +295,7 @@ module Rodauth
 
     def login_required
       set_redirect_error_status(login_required_error_status)
+      set_error_reason :login_required
       set_redirect_error_flash require_login_error_flash
       redirect require_login_redirect
     end

--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -53,6 +53,7 @@ module Rodauth
 
       if require_password_authentication? && has_password?
         set_redirect_error_status(password_authentication_required_error_status)
+        set_error_reason :password_authentication_required
         set_redirect_error_flash password_authentication_required_error_flash
         set_session_value(confirm_password_redirect_session_key, request.fullpath)
         redirect password_authentication_required_redirect

--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -58,6 +58,7 @@ module Rodauth
           _email_auth_request
         else
           set_redirect_error_status(no_matching_login_error_status)
+          set_error_reason :no_matching_login
           set_redirect_error_flash email_auth_request_error_flash
         end
 
@@ -90,6 +91,7 @@ module Rodauth
         key = session[email_auth_session_key] || param(email_auth_key_param)
         unless account_from_email_auth_key(key)
           set_redirect_error_status(invalid_key_error_status)
+          set_error_reason :invalid_email_auth_key
           set_redirect_error_flash email_auth_error_flash
           redirect email_auth_email_sent_redirect
         end

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -84,6 +84,7 @@ module Rodauth
           set_notice_flash unlock_account_request_notice_flash
         else
           set_redirect_error_status(no_matching_login_error_status)
+          set_error_reason :no_matching_login
           set_redirect_error_flash no_matching_login_message.to_s.capitalize
         end
 
@@ -116,6 +117,7 @@ module Rodauth
         key = session[unlock_account_session_key] || param(unlock_account_key_param)
         unless account_from_unlock_key(key)
           set_redirect_error_status invalid_key_error_status
+          set_error_reason :invalid_unlock_account_key
           set_redirect_error_flash no_matching_unlock_account_key_error_flash
           redirect unlock_account_request_redirect
         end

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -226,6 +226,7 @@ module Rodauth
     def require_otp_setup
       unless otp_exists?
         set_redirect_error_status(two_factor_not_setup_error_status)
+        set_error_reason :two_factor_not_setup
         set_redirect_error_flash two_factor_not_setup_error_flash
         redirect two_factor_need_setup_redirect
       end

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -123,6 +123,7 @@ module Rodauth
         key = session[reset_password_session_key] || param(reset_password_key_param)
         unless account_from_reset_password_key(key)
           set_redirect_error_status(invalid_key_error_status)
+          set_error_reason :invalid_reset_password_key
           set_redirect_error_flash reset_password_error_flash
           redirect reset_password_email_sent_redirect
         end

--- a/lib/rodauth/features/session_expiration.rb
+++ b/lib/rodauth/features/session_expiration.rb
@@ -38,6 +38,7 @@ module Rodauth
     def expire_session
       clear_session
       set_redirect_error_status session_expiration_error_status
+      set_error_reason :session_expired
       set_redirect_error_flash session_expiration_error_flash
       redirect session_expiration_redirect
     end

--- a/lib/rodauth/features/single_session.rb
+++ b/lib/rodauth/features/single_session.rb
@@ -57,6 +57,7 @@ module Rodauth
     def no_longer_active_session
       clear_session
       set_redirect_error_status inactive_session_error_status
+      set_error_reason :inactive_session
       set_redirect_error_flash single_session_error_flash
       redirect single_session_redirect
     end

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -186,6 +186,7 @@ module Rodauth
 
       if sms_needs_confirmation?
         set_redirect_error_status(sms_needs_confirmation_error_status)
+        set_error_reason :sms_needs_confirmation
         set_redirect_error_flash sms_needs_confirmation_error_flash
         redirect sms_needs_confirmation_redirect
       end
@@ -254,6 +255,7 @@ module Rodauth
 
         sms_confirm_failure
         set_redirect_error_status(invalid_key_error_status)
+        set_error_reason :invalid_sms_confirmation_code
         set_redirect_error_flash sms_invalid_confirmation_code_error_flash
         redirect sms_needs_setup_redirect
       end
@@ -302,6 +304,7 @@ module Rodauth
     def require_sms_setup
       unless sms_setup?
         set_redirect_error_status(two_factor_not_setup_error_status)
+        set_error_reason :sms_not_setup
         set_redirect_error_flash sms_not_setup_error_flash
         redirect sms_needs_setup_redirect
       end
@@ -310,6 +313,7 @@ module Rodauth
     def require_sms_not_setup
       if sms_setup?
         set_redirect_error_status(sms_already_setup_error_status)
+        set_error_reason :sms_already_setup
         set_redirect_error_flash sms_already_setup_error_flash
         redirect sms_already_setup_redirect
       end
@@ -320,6 +324,7 @@ module Rodauth
 
       if sms_locked_out?
         set_redirect_error_status(lockout_error_status)
+        set_error_reason :sms_locked_out
         set_redirect_error_flash sms_lockout_error_flash
         redirect sms_lockout_redirect
       end

--- a/lib/rodauth/features/two_factor_base.rb
+++ b/lib/rodauth/features/two_factor_base.rb
@@ -144,6 +144,7 @@ module Rodauth
       return if uses_two_factor_authentication?
 
       set_redirect_error_status(two_factor_not_setup_error_status)
+      set_error_reason :two_factor_not_setup
       set_redirect_error_flash two_factor_not_setup_error_flash
       redirect two_factor_need_setup_redirect
     end
@@ -151,6 +152,7 @@ module Rodauth
     def require_two_factor_not_authenticated(auth_type = nil)
       if two_factor_authenticated? || (auth_type && two_factor_login_type_match?(auth_type))
         set_redirect_error_status(two_factor_already_authenticated_error_status)
+        set_error_reason :two_factor_already_authenticated
         set_redirect_error_flash two_factor_already_authenticated_error_flash
         redirect two_factor_already_authenticated_redirect
       end
@@ -162,6 +164,7 @@ module Rodauth
           set_session_value(two_factor_auth_redirect_session_key, request.fullpath)
         end
         set_redirect_error_status(two_factor_need_authentication_error_status)
+        set_error_reason :two_factor_need_authentication
         set_redirect_error_flash two_factor_need_authentication_error_flash
         redirect two_factor_auth_required_redirect
       end

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -87,6 +87,7 @@ module Rodauth
           set_notice_flash verify_account_email_sent_notice_flash
         else
           set_redirect_error_status(no_matching_login_error_status)
+          set_error_reason :no_matching_login
           set_redirect_error_flash verify_account_resend_error_flash
         end
         
@@ -120,6 +121,7 @@ module Rodauth
         key = session[verify_account_session_key] || param(verify_account_key_param)
         unless account_from_verify_account_key(key)
           set_redirect_error_status(invalid_key_error_status)
+          set_error_reason :invalid_verify_account_key
           set_redirect_error_flash verify_account_error_flash
           redirect verify_account_redirect
         end
@@ -192,6 +194,7 @@ module Rodauth
     def new_account(login)
       if account_from_login(login) && allow_resending_verify_account_email?
         set_redirect_error_status(unopen_account_error_status)
+        set_error_reason :already_an_unopen_account_with_this_login
         set_error_flash attempt_to_create_unverified_account_error_flash
         response.write resend_verify_account_view
         request.halt
@@ -269,6 +272,7 @@ module Rodauth
     def before_login_attempt
       unless open_account?
         set_redirect_error_status(unopen_account_error_status)
+        set_error_reason :unverified_account
         set_error_flash attempt_to_login_to_unverified_account_error_flash
         response.write resend_verify_account_view
         request.halt

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -74,6 +74,7 @@ module Rodauth
         key = session[verify_login_change_session_key] || param(verify_login_change_key_param)
         unless account_from_verify_login_change_key(key)
           set_redirect_error_status(invalid_key_error_status)
+          set_error_reason :invalid_verify_login_key
           set_redirect_error_flash verify_login_change_error_flash
           redirect verify_login_change_redirect
         end
@@ -82,6 +83,7 @@ module Rodauth
           before_verify_login_change
           unless verify_login_change
             set_redirect_error_status(invalid_key_error_status)
+            set_error_reason :already_an_account_with_this_login
             set_redirect_error_flash verify_login_change_duplicate_account_error_flash
             redirect verify_login_change_duplicate_account_redirect
           end

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -392,6 +392,7 @@ module Rodauth
     def require_webauthn_setup
       unless webauthn_setup?
         set_redirect_error_status(webauthn_not_setup_error_status)
+        set_error_reason :webauthn_not_setup
         set_redirect_error_flash webauthn_not_setup_error_flash
         redirect two_factor_need_setup_redirect
       end

--- a/spec/active_sessions_spec.rb
+++ b/spec/active_sessions_spec.rb
@@ -324,14 +324,14 @@ describe 'Rodauth active sessions feature' do
 
     json_request.must_equal [200, [2]]
     @authorization = authorization1
-    json_request.must_equal [401, {'error'=>"This session has been logged out"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out"}]
 
     json_login
     json_request.must_equal [200, [1]]
 
     authorization2 = @authorization
     @authorization = authorization1
-    json_request.must_equal [401, {'error'=>"This session has been logged out"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out"}]
 
     @authorization = authorization2
     json_request.must_equal [200, [1]]
@@ -349,12 +349,11 @@ describe 'Rodauth active sessions feature' do
     res.must_equal [200, {"success"=>'You have been logged out'}]
 
     @authorization = authorization2
-    json_request.must_equal [401, {'error'=>"This session has been logged out"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out"}]
     json_request.must_equal [200, [2]]
 
     @authorization = authorization3
-    json_request.must_equal [401, {'error'=>"This session has been logged out"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out"}]
     json_request.must_equal [200, [2]]
   end
 end
-

--- a/spec/confirm_password_spec.rb
+++ b/spec/confirm_password_spec.rb
@@ -150,7 +150,7 @@ describe 'Rodauth confirm password feature' do
       json_request('/reset').must_equal [200, [1]]
 
       res = json_request('/page')
-      res.must_equal [401, {'error'=>"You need to confirm your password before continuing"}]
+      res.must_equal [401, {'reason'=>'password_authentication_required', 'error'=>"You need to confirm your password before continuing"}]
 
       res = json_request('/confirm-password', :password=>'0123456789')
       res.must_equal [200, {'success'=>"Your password has been confirmed"}]

--- a/spec/email_auth_spec.rb
+++ b/spec/email_auth_spec.rb
@@ -321,24 +321,23 @@ describe 'Rodauth email auth feature' do
       end
 
       res = json_request('/email-auth-request')
-      res.must_equal [401, {"error"=>"There was an error requesting an email link to authenticate"}]
+      res.must_equal [401, {"reason"=>"no_matching_login", "error"=>"There was an error requesting an email link to authenticate"}]
 
       res = json_request('/email-auth-request', :login=>'foo@example2.com')
-      res.must_equal [401, {"error"=>"There was an error requesting an email link to authenticate"}]
+      res.must_equal [401, {"reason"=>"no_matching_login", "error"=>"There was an error requesting an email link to authenticate"}]
 
       res = json_request('/email-auth-request', :login=>'foo@example.com')
       res.must_equal [200, {"success"=>"An email has been sent to you with a link to login to your account"}]
 
       link = email_link(/key=.+$/)
       res = json_request('/email-auth')
-      res.must_equal [401, {"error"=>"There was an error logging you in"}]
+      res.must_equal [401, {"reason"=>"invalid_email_auth_key", "error"=>"There was an error logging you in"}]
 
       res = json_request('/email-auth', :key=>link[4...-1])
-      res.must_equal [401, {"error"=>"There was an error logging you in"}]
+      res.must_equal [401, {"reason"=>"invalid_email_auth_key", "error"=>"There was an error logging you in"}]
 
       res = json_request('/email-auth', :key=>link[4..-1])
       res.must_equal [200, {"success"=>"You have been logged in"}]
     end
   end
 end
-

--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -234,15 +234,15 @@ describe "Rodauth http basic auth feature" do
 
       @authorization = nil
       res = basic_auth_json_request(:auth=>'.')
-      res.must_equal [401, {'error'=>"Please login to continue"}]
+      res.must_equal [401, {"reason"=>"login_required", 'error'=>"Please login to continue"}]
 
       @authorization = nil
       res = basic_auth_json_request(:username=>'foo@example2.com')
-      res.must_equal [401, {'error'=>"Please login to continue", "field-error"=>["login", "no matching login"]}]
+      res.must_equal [401, {"reason"=>"login_required", 'error'=>"Please login to continue", "field-error"=>["login", "no matching login"]}]
 
       @authorization = nil
       res = basic_auth_json_request(:password=>'012345678')
-      res.must_equal [401, {'error'=>"Please login to continue", "field-error"=>["password", "invalid password"]}]
+      res.must_equal [401, {"reason"=>"login_required", 'error'=>"Please login to continue", "field-error"=>["password", "invalid password"]}]
 
       @authorization = nil
       res = newline_basic_auth_json_request

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -11,10 +11,10 @@ describe 'Rodauth login feature' do
     end
 
     res = json_request("/jwt-refresh", :headers=>{'HTTP_AUTHORIZATION'=>'Basic foo'})
-    res.must_equal [401, {'error'=>'Please login to continue'}]
+    res.must_equal [401, {"reason"=>"login_required", 'error'=>'Please login to continue'}]
 
     res = json_request("/", :headers=>{'HTTP_AUTHORIZATION'=>'Digest foo'})
-    res.must_equal [401, {'error'=>'Please login to continue'}]
+    res.must_equal [401, {"reason"=>"login_required", 'error'=>'Please login to continue'}]
   end
 
   it "should require json request content type in only json mode for rodauth endpoints only" do
@@ -182,7 +182,7 @@ describe 'Rodauth login feature' do
         {'hello' => 'world'}.to_json
       end
       res = json_request("/")
-      res.must_equal [401, {'error'=>'Please login to continue'}]
+      res.must_equal [401, {'reason'=>'login_required', 'error'=>'Please login to continue'}]
 
       # We can login
       res = jwt_refresh_login
@@ -279,7 +279,7 @@ describe 'Rodauth login feature' do
         {'hello' => 'world'}.to_json
       end
       res = json_request("/")
-      res.must_equal [401, {'error'=>'Please login to continue'}]
+      res.must_equal [401, {'reason'=>'login_required', 'error'=>'Please login to continue'}]
 
       res = jwt_refresh_login
       refresh_token = res.last['refresh_token']
@@ -294,7 +294,7 @@ describe 'Rodauth login feature' do
       post_refresh_access_token = @authorization
       @authorization = pre_refresh_access_token
       res = json_request("/")
-      res.must_equal [401, {'error'=>'This session has been logged out'}]
+      res.must_equal [401, {'reason'=>'inactive_session', 'error'=>'This session has been logged out'}]
 
       @authorization = post_refresh_access_token
       res = json_request("/")
@@ -346,7 +346,7 @@ describe 'Rodauth login feature' do
     res = json_request("/jwt-refresh", :refresh_token=>res.last['refresh_token'])
     res.must_equal [401, {"error"=>"no JWT access token provided during refresh"}]
 
-    json_request('/').must_equal [401, {"error"=>"Please login to continue"}]
+    json_request('/').must_equal [401, {"reason"=>"login_required", "error"=>"Please login to continue"}]
   end
 
   it "should not allow refreshing token when providing expired access token" do

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -11,10 +11,10 @@ describe 'Rodauth login feature' do
     end
 
     res = json_request("/", :headers=>{'HTTP_AUTHORIZATION'=>'Basic foo'})
-    res.must_equal [401, {'error'=>'Please login to continue'}]
+    res.must_equal [401, {"reason"=>"login_required", 'error'=>'Please login to continue'}]
 
     res = json_request("/", :headers=>{'HTTP_AUTHORIZATION'=>'Digest foo'})
-    res.must_equal [401, {'error'=>'Please login to continue'}]
+    res.must_equal [401, {"reason"=>"login_required", 'error'=>'Please login to continue'}]
   end
 
   it "should return error message if invalid JWT format used in request Authorization header" do
@@ -46,7 +46,7 @@ describe 'Rodauth login feature' do
     status, headers, body = json_request("/", :headers=>{'CONTENT_TYPE'=>'text/html'}, :include_headers=>true)
     status.must_equal 401
     headers['Content-Type'].must_equal 'application/json'
-    JSON.parse(body.join).must_equal("error"=>"Please login to continue")
+    JSON.parse(body.join).must_equal("reason"=>"login_required", "error"=>"Please login to continue")
   end
 
   it "should not check CSRF for json requests" do

--- a/spec/lockout_spec.rb
+++ b/spec/lockout_spec.rb
@@ -242,7 +242,7 @@ describe 'Rodauth lockout feature' do
       end
 
       res = json_request('/unlock-account-request', :login=>'foo@example.com')
-      res.must_equal [401, {'error'=>"No matching login"}]
+      res.must_equal [401, {'reason'=>'no_matching_login', 'error'=>"No matching login"}]
 
       res = json_login(:pass=>'1', :no_check=>true)
       res.must_equal [401, {'reason'=>"invalid_password",'error'=>"There was an error logging in", "field-error"=>["password", "invalid password"]}]
@@ -261,14 +261,14 @@ describe 'Rodauth lockout feature' do
       end
 
       res = json_request('/unlock-account')
-      res.must_equal [401, {'error'=>"There was an error unlocking your account: invalid or expired unlock account key"}]
+      res.must_equal [401, {'reason'=>'invalid_unlock_account_key', 'error'=>"There was an error unlocking your account: invalid or expired unlock account key"}]
 
       res = json_request('/unlock-account-request', :login=>'foo@example.com')
       res.must_equal [200, {'success'=>"An email has been sent to you with a link to unlock your account"}]
 
       link = email_link(/key=.+$/)
       res = json_request('/unlock-account', :key=>link[4...-1])
-      res.must_equal [401, {'error'=>"There was an error unlocking your account: invalid or expired unlock account key"}]
+      res.must_equal [401, {'reason'=>'invalid_unlock_account_key', 'error'=>"There was an error unlocking your account: invalid or expired unlock account key"}]
 
       res = json_request('/unlock-account', :key=>link[4..-1])
       res.must_equal [200, {'success'=>"Your account has been unlocked"}]

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -421,7 +421,7 @@ describe 'Rodauth login feature' do
       json_request.must_equal [200, 2]
 
       res = json_request("/foo")
-      res.must_equal [401, {"error"=>"Please login to continue"}]
+      res.must_equal [401, {"reason"=>"login_required", "error"=>"Please login to continue"}]
 
       res = json_request("/login", :login=>'foo@example2.com', :password=>'0123456789')
       res.must_equal [401, {'reason'=>"no_matching_login",'error'=>"There was an error logging in", "field-error"=>["login", "no matching login"]}]

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -259,7 +259,7 @@ describe 'Rodauth reset_password feature' do
       res.must_equal [401, {'reason'=>"invalid_password","field-error"=>["password", "invalid password"], "error"=>"There was an error logging in"}]
 
       res = json_request('/reset-password')
-      res.must_equal [401, {"error"=>"There was an error resetting your password"}]
+      res.must_equal [401, {"reason"=>"invalid_reset_password_key", "error"=>"There was an error resetting your password"}]
 
       res = json_request('/reset-password-request', :login=>'foo@example2.com')
       res.must_equal [401, {'reason'=>"no_matching_login","field-error"=>["login", "no matching login"], "error"=>"There was an error requesting a password reset"}]
@@ -269,7 +269,7 @@ describe 'Rodauth reset_password feature' do
 
       link = email_link(/key=.+$/)
       res = json_request('/reset-password', :key=>link[4...-1])
-      res.must_equal [401, {"error"=>"There was an error resetting your password"}]
+      res.must_equal [401, {"reason"=>"invalid_reset_password_key", "error"=>"There was an error resetting your password"}]
 
       res = json_request('/reset-password', :key=>link[4..-1], :password=>'1', "password-confirm"=>'2')
       res.must_equal [422, {'reason'=>"passwords_do_not_match","error"=>"There was an error resetting your password", "field-error"=>["password", 'passwords do not match']}]

--- a/spec/session_expiration_spec.rb
+++ b/spec/session_expiration_spec.rb
@@ -88,27 +88,27 @@ describe 'Rodauth session expiration feature' do
     json_request.must_equal [200, [1]]
 
     inactivity = -1
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
     json_login
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
 
     inactivity = 10
     json_login
     max_lifetime = -1
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
     json_login
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
 
     max_lifetime = 10
     json_login
     json_request.must_equal [200, [1]]
     json_request('/set-creation').must_equal [200, [5]]
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
 
     json_login
     json_request.must_equal [200, [1]]
     json_request('/remove-creation').must_equal [200, [4]]
-    json_request.must_equal [401, {'error'=>"This session has expired, please login again"}]
+    json_request.must_equal [401, {'reason'=>'session_expired', 'error'=>"This session has expired, please login again"}]
 
     expiration_default = false
     json_login
@@ -117,4 +117,3 @@ describe 'Rodauth session expiration feature' do
     json_request.must_equal [200, [1]]
   end
 end
-

--- a/spec/single_session_spec.rb
+++ b/spec/single_session_spec.rb
@@ -132,23 +132,23 @@ describe 'Rodauth single session feature' do
 
     json_request.must_equal [200, [2]]
     @authorization = authorization1
-    json_request.must_equal [401, {'error'=>"This session has been logged out as another session has become active"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out as another session has become active"}]
 
     json_login
     json_request.must_equal [200, [1]]
 
     authorization2 = @authorization
     @authorization = authorization1
-    json_request.must_equal [401, {'error'=>"This session has been logged out as another session has become active"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out as another session has become active"}]
 
     @authorization = authorization2
     json_request.must_equal [200, [1]]
 
     json_request('/clear').must_equal [200, [3]]
-    json_request.must_equal [401, {'error'=>"This session has been logged out as another session has become active"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out as another session has become active"}]
     json_request.must_equal [200, [2]]
 
     @authorization = authorization2
-    json_request.must_equal [401, {'error'=>"This session has been logged out as another session has become active"}]
+    json_request.must_equal [401, {'reason'=>'inactive_session', 'error'=>"This session has been logged out as another session has become active"}]
   end
 end

--- a/spec/verify_account_spec.rb
+++ b/spec/verify_account_spec.rb
@@ -283,25 +283,28 @@ describe 'Rodauth verify_account feature' do
       res = json_request('/create-account', :login=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
       res.must_equal [200, {'success'=>"An email has been sent to you with a link to verify your account"}]
       link = email_link(/key=.+$/, 'foo@example2.com')
+      
+      res = json_request('/create-account', :login=>'foo@example2.com', :password=>'0123456789', "password-confirm"=>'0123456789')
+      res.must_equal [403, {"reason"=>"already_an_unopen_account_with_this_login", "error"=>"The account you tried to create is currently awaiting verification"}]
 
       res = json_request('/verify-account-resend', :login=>'foo@example.com')
-      res.must_equal [401, {'error'=>"Unable to resend verify account email"}]
+      res.must_equal [401, {'reason'=> "no_matching_login", 'error'=>"Unable to resend verify account email"}]
 
       res = json_request('/verify-account-resend', :login=>'foo@example3.com')
-      res.must_equal [401, {'error'=>"Unable to resend verify account email"}]
+      res.must_equal [401, {'reason'=> "no_matching_login", 'error'=>"Unable to resend verify account email"}]
 
       res = json_request('/login', :login=>'foo@example2.com',:password=>'0123456789')
-      res.must_equal [403, {'error'=>"The account you tried to login with is currently awaiting verification"}]
+      res.must_equal [403, {'reason'=> "unverified_account", 'error'=>"The account you tried to login with is currently awaiting verification"}]
 
       res = json_request('/verify-account-resend', :login=>'foo@example2.com')
       res.must_equal [200, {'success'=>"An email has been sent to you with a link to verify your account"}]
       email_link(/key=.+$/, 'foo@example2.com').must_equal link
 
       res = json_request('/verify-account')
-      res.must_equal [401, {'error'=>"Unable to verify account"}]
+      res.must_equal [401, {'reason'=> "invalid_verify_account_key", 'error'=>"Unable to verify account"}]
 
       res = json_request('/verify-account', :key=>link[4...-1])
-      res.must_equal [401, {"error"=>"Unable to verify account"}]
+      res.must_equal [401, {'reason'=> "invalid_verify_account_key", "error"=>"Unable to verify account"}]
 
       res = json_request('/verify-account', :key=>link[4..-1])
       res.must_equal [200, {"success"=>"Your account has been verified"}]

--- a/spec/verify_login_change_spec.rb
+++ b/spec/verify_login_change_spec.rb
@@ -218,10 +218,10 @@ describe 'Rodauth verify_login_change feature' do
       new_link.wont_equal link
 
       res = json_request('/verify-login-change')
-      res.must_equal [401, {"error"=>"Unable to verify login change"}]
+      res.must_equal [401, {"reason"=>"invalid_verify_login_key", "error"=>"Unable to verify login change"}]
 
       res = json_request('/verify-login-change', :key=>link[4..-1])
-      res.must_equal [401, {"error"=>"Unable to verify login change"}]
+      res.must_equal [401, {"reason"=>"invalid_verify_login_key", "error"=>"Unable to verify login change"}]
 
       res = json_request('/verify-login-change', :key=>new_link[4..-1])
       res.must_equal [200, {"success"=>"Your login change has been verified"}]

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -453,7 +453,7 @@ describe 'Rodauth webauthn feature' do
       webauthn_client2 = WebAuthn::FakeClient.new(origin)
 
       %w'/webauthn-auth /webauthn-remove'.each do |path|
-        json_request(path).must_equal [403, {'error'=>'This account has not been setup for WebAuthn authentication'}]
+        json_request(path).must_equal [403, {'reason'=>'webauthn_not_setup', 'error'=>'This account has not been setup for WebAuthn authentication'}]
       end
 
       res = json_request('/webauthn-setup', :password=>'0123456789')


### PR DESCRIPTION
This is a follow up to #162

`set_error_reason` was not called on redirections It is now set everywhere `set_redirect_error_status` is called.

Documentation has been updated with the new reasons, I tried to reuse the existing ones where possible.