### PR TITLE
Update templates for Boostrap 5

### DIFF
--- a/templates/button.str
+++ b/templates/button.str
@@ -1,3 +1,3 @@
-<div class="form-group">
+<div class="form-group mb-3">
   <input type="submit" #{"name=\"#{h opts[:name]}\"" if opts[:name]} class="#{h(opts[:class] || 'btn btn-primary')}" value="#{h value}"/>
 </div>

--- a/templates/change-password.str
+++ b/templates/change-password.str
@@ -2,8 +2,8 @@
   #{rodauth.change_password_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.change_password_requires_password?}
-  <div class="form-group">
-    <label for="new-password">#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}</label>
+  <div class="form-group mb-3">
+    <label for="new-password" class="form-label">#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}</label>
     #{rodauth.input_field_string(rodauth.new_password_param, 'new-password', :type => 'password', :autocomplete=>"new-password")}
   </div>
   #{rodauth.render('password-confirm-field') if rodauth.require_password_confirmation?}

--- a/templates/global-logout-field.str
+++ b/templates/global-logout-field.str
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group mb-3">
   <div class="form-check checkbox">
     <input type="checkbox" name="#{rodauth.global_logout_param}" class="form-check-input" id="global-logout" value="t"/>
     <label class="rodauth-global-logout-label form-check-label" for="global-logout">#{rodauth.global_logout_label}</label>

--- a/templates/login-confirm-field.str
+++ b/templates/login-confirm-field.str
@@ -1,4 +1,4 @@
-<div class="form-group">
-  <label for="login-confirm">#{rodauth.login_confirm_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="login-confirm" class="form-label">#{rodauth.login_confirm_label}#{rodauth.input_field_label_suffix}</label>
   #{rodauth.input_field_string(rodauth.login_confirm_param, 'login-confirm', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
 </div>

--- a/templates/login-display.str
+++ b/templates/login-display.str
@@ -1,5 +1,5 @@
-<div class="form-group">
+<div class="form-group mb-3">
   #{rodauth.login_hidden_field}
-  <label for="login">#{rodauth.login_label}</label>
+  <label for="login" class="form-label">#{rodauth.login_label}</label>
   <div class="form-control-plaintext form-control-static">#{h rodauth.param(rodauth.login_param)}</div>
 </div>

--- a/templates/login-field.str
+++ b/templates/login-field.str
@@ -1,4 +1,4 @@
-<div class="form-group">
-  <label for="login">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="login" class="form-label">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
   #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
 </div>

--- a/templates/otp-auth-code-field.str
+++ b/templates/otp-auth-code-field.str
@@ -1,5 +1,5 @@
-<div class="form-group">
-  <label for="otp-auth-code">#{rodauth.otp_auth_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="otp-auth-code" class="form-label">#{rodauth.otp_auth_label}#{rodauth.input_field_label_suffix}</label>
   <div class="row">
     <div class="col-sm-3">
       #{rodauth.input_field_string(rodauth.otp_auth_param, 'otp-auth-code', :value=>'', :autocomplete=>"off", :inputmode=>'numeric')}

--- a/templates/otp-setup.str
+++ b/templates/otp-setup.str
@@ -3,14 +3,14 @@
   <input type="hidden" id="otp-key" name="#{rodauth.otp_setup_param}" value="#{rodauth.otp_user_key}" />
   #{"<input type=\"hidden\" id=\"otp-hmac-secret\" name=\"#{rodauth.otp_setup_raw_param}\" value=\"#{rodauth.otp_key}\" />" if rodauth.otp_keys_use_hmac?}
   #{rodauth.csrf_tag}
-  <div class="form-group">
+  <div class="form-group mb-3">
     <p>#{rodauth.otp_secret_label}: #{rodauth.otp_user_key}</p>
     <p>#{rodauth.otp_provisioning_uri_label}: #{rodauth.otp_provisioning_uri}</p>
   </div>
  
   <div class="row">
     <div class="col-lg-6 col-lg">
-      <div class="form-group">
+      <div class="form-group mb-3">
         <p>#{rodauth.otp_qr_code}</p>
       </div>
     </div>

--- a/templates/password-confirm-field.str
+++ b/templates/password-confirm-field.str
@@ -1,4 +1,4 @@
-<div class="form-group">
-  <label for="password-confirm">#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="password-confirm" class="form-label">#{rodauth.password_confirm_label}#{rodauth.input_field_label_suffix}</label>
   #{rodauth.input_field_string(rodauth.password_confirm_param, 'password-confirm', :type => 'password', :autocomplete=>'new-password')}
 </div>

--- a/templates/password-field.str
+++ b/templates/password-field.str
@@ -1,4 +1,4 @@
-<div class="form-group">
-  <label for="password">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="password" class="form-label">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
   #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>rodauth.password_field_autocomplete_value)}
 </div>

--- a/templates/recovery-auth.str
+++ b/templates/recovery-auth.str
@@ -1,8 +1,8 @@
 <form method="post" class="rodauth" role="form" id="recovery-auth-form">
   #{rodauth.recovery_auth_additional_form_tags}
   #{rodauth.csrf_tag}
-  <div class="form-group">
-    <label for="recovery-code">#{rodauth.recovery_codes_label}#{rodauth.input_field_label_suffix}</label>
+  <div class="form-group mb-3">
+    <label for="recovery-code" class="form-label">#{rodauth.recovery_codes_label}#{rodauth.input_field_label_suffix}</label>
     #{rodauth.input_field_string(rodauth.recovery_codes_param, 'recovery-code', :value => '', :autocomplete=>'off')}
   </div>
   #{rodauth.button(rodauth.recovery_auth_button)}

--- a/templates/remember.str
+++ b/templates/remember.str
@@ -1,7 +1,7 @@
 <form method="post" class="rodauth" role="form" id="remember-form">
   #{rodauth.remember_additional_form_tags}
   #{rodauth.csrf_tag}
-  <fieldset class="form-group">
+  <fieldset class="form-group mb-3">
     <div class="form-check radio">
       <input type="radio" name="#{rodauth.remember_param}" id="remember-remember" value="#{h rodauth.remember_remember_param_value}" class="form-check-input"/>
       <label class="form-check-label" for="remember-remember">#{rodauth.remember_remember_label}</label>

--- a/templates/sms-code-field.str
+++ b/templates/sms-code-field.str
@@ -1,5 +1,5 @@
-<div class="form-group">
-  <label for="sms-code">#{rodauth.sms_code_label}#{rodauth.input_field_label_suffix}</label>
+<div class="form-group mb-3">
+  <label for="sms-code" class="form-label">#{rodauth.sms_code_label}#{rodauth.input_field_label_suffix}</label>
   <div class="row">
     <div class="col-sm-3">
       #{rodauth.input_field_string(rodauth.sms_code_param, 'sms-code', :value => '', :autocomplete=>'one-time-code', :inputmode=>'numeric')}

--- a/templates/sms-setup.str
+++ b/templates/sms-setup.str
@@ -2,8 +2,8 @@
   #{rodauth.sms_setup_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
-  <div class="form-group">
-    <label for="sms-phone">#{rodauth.sms_phone_label}#{rodauth.input_field_label_suffix}</label>
+  <div class="form-group mb-3">
+    <label for="sms-phone" class="form-label">#{rodauth.sms_phone_label}#{rodauth.input_field_label_suffix}</label>
     <div class="row">
       <div class="col-sm-3">
         #{rodauth.input_field_string(rodauth.sms_phone_param, 'sms-phone', :type=>rodauth.sms_phone_input_type, :autocomplete=>'tel')}

--- a/templates/webauthn-remove.str
+++ b/templates/webauthn-remove.str
@@ -2,7 +2,7 @@
   #{rodauth.webauthn_remove_additional_form_tags}
   #{rodauth.csrf_tag}
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
-  <fieldset class="form-group">
+  <fieldset class="form-group mb-3">
     #{(usage = rodauth.account_webauthn_usage; last_id = usage.keys.last; usage;).map do |id, last_use|
       input = rodauth.input_field_string(rodauth.webauthn_remove_param, "webauthn-remove-#{h id}", :type=>'radio', :class=>"form-check-input", :skip_error_message=>true, :value=>id, :required=>false)
       label = "<label class=\"rodauth-webauthn-id form-check-label\" for=\"webauthn-remove-#{h id}\">Last Use: #{last_use}</label>"


### PR DESCRIPTION
[Bootstrap 5.0 was released](https://blog.getbootstrap.com/2021/05/05/bootstrap-5/) yesterday. This PR updates the templates with some of the changes:

* label tags now require the `form-label` class
* `form-group` class has been removed, the official docs use `mb-3` instead, so we use them here as well
