### PR TITLE
Make jwt_refresh work with active_sessions when allowing expired JWTs for refresh

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -32,6 +32,8 @@ module Rodauth
     )
 
     route do |r|
+      # For backward compatibility, unused in core Rodauth
+      # RODAUTH3: Remove
       @jwt_refresh_route = true
       before_jwt_refresh_route
 
@@ -135,7 +137,7 @@ module Rodauth
     end
 
     def _jwt_decode_opts
-      if allow_refresh_with_expired_jwt_access_token? && @jwt_refresh_route
+      if allow_refresh_with_expired_jwt_access_token? && request.path == jwt_refresh_path
         Hash[super].merge!(:verify_expiration=>false)
       else
         super

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -405,4 +405,31 @@ describe 'Rodauth login feature' do
 
     json_request('/').must_equal [200, {"authenticated_by"=>["password"]}]
   end
+
+  it "should allow refreshing token when providing expired access token if configured with active_sessions" do
+    period = -2
+    rodauth do
+      enable :active_sessions, :login, :logout, :jwt_refresh, :close_account
+      hmac_secret SecureRandom.random_bytes(32)
+      jwt_secret '1'
+      jwt_access_token_period{period}
+      allow_refresh_with_expired_jwt_access_token? true
+    end
+    roda(:jwt) do |r|
+      rodauth.check_active_session
+      r.rodauth
+      rodauth.require_authentication
+      response['Content-Type'] = 'application/json'
+      {'authenticated_by' => rodauth.authenticated_by}.to_json
+    end
+
+    res = jwt_refresh_login
+    refresh_token = res.last['refresh_token']
+    period = 1800
+
+    res = json_request("/jwt-refresh", :refresh_token=>refresh_token)
+    jwt_refresh_validate(res)
+
+    json_request('/').must_equal [200, {"authenticated_by"=>["password"]}]
+  end
 end


### PR DESCRIPTION
If `rodauth.check_active_session` is called before `r.rodauth` then `@jwt_refresh_route` is not yet set and the JWT is decoded with `:verify_expiration: true`, which fails even if we want to allow expired access tokens to be provided for refresh.

As discussed on IRC this seems to be the best way to detect if the request is for the refresh route while not beeing in the route handler itself.

The added test is failing without this patch, and green with it.