### PR TITLE
Remove registration of internal rodauth class

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -245,7 +245,8 @@ module Rodauth
 
       params = {}
 
-      rodauth = roda_class.new(env).rodauth(configuration_name)
+      scope = roda_class.new(env)
+      rodauth = new(scope)
       rodauth.session = session
       rodauth.params = params
 
@@ -308,9 +309,6 @@ module Rodauth
       end
       internal_class.send(:extend, InternalRequestClassMethods)
       internal_class.send(:include, InternalRequestMethods)
-      configuration_name = Object.new
-      internal_class.instance_variable_set(:@configuration_name, configuration_name)
-      klass.roda_class.plugin(:rodauth, :name=>configuration_name, :auth_class=>internal_class)
 
       if blocks = klass.instance_variable_get(:@internal_request_configuration_blocks)
         configuration = internal_class.configuration


### PR DESCRIPTION
As discussed on the google group, this modifies instantiating of internal rodauth instance in a way that doesn't require the internal rodauth class to be registered on the roda class. This helps it remain invisible when introspecting the roda class.
