### PR TITLE
Add :params option for custom parameters to internal_request feature

### DIFF
--- a/doc/internal_request.rdoc
+++ b/doc/internal_request.rdoc
@@ -32,6 +32,7 @@ if you have special requirements:
 :authenticated_by :: The array of strings to use for how the internal request's session was authenticated.
 :env :: A hash for the environment to use.
 :session :: A hash for the session to use.
+:params :: A hash of custom parameters.
 
 All remaining options are considered parameters. Using the
 previous example:

--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -244,6 +244,7 @@ module Rodauth
       session.merge!(opts.delete(:session)) if opts[:session]
 
       params = {}
+      params.merge!(opts.delete(:params)) if opts[:params]
 
       rodauth = roda_class.new(env).rodauth(configuration_name)
       rodauth.session = session

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -662,7 +662,7 @@ describe 'Rodauth' do
     rodauth do
       enable :login, :logout, :create_account, :change_login, :internal_request
       before_create_account_route do
-        params[login_param] += request.env[:at] + session[:domain]
+        params[login_param] += param('name') + request.env[:at] + session[:domain]
       end
       before_change_login_route do
         params[login_param] += authenticated_by.first
@@ -673,13 +673,13 @@ describe 'Rodauth' do
       view :content=>""
     end
 
-    app.rodauth.create_account(:login=>'foo', :password=>'0123456789', :env=>{:at=>'@'}, :session=>{:domain=>'g.com'}).must_be_nil
+    app.rodauth.create_account(:login=>'foo', :password=>'0123456789', :params=>{'name'=>'bar'}, :env=>{:at=>'@'}, :session=>{:domain=>'g.com'}).must_be_nil
 
-    login(:login=>'foo@g.com')
+    login(:login=>'foobar@g.com')
     page.find('#notice_flash').text.must_equal 'You have been logged in'
     logout
 
-    app.rodauth.change_login(:account_id=>DB[:accounts].where(:email=>'foo@g.com').get(:id), :login=>'foo@h.', :authenticated_by=>['com']).must_be_nil
+    app.rodauth.change_login(:account_id=>DB[:accounts].where(:email=>'foobar@g.com').get(:id), :login=>'foo@h.', :authenticated_by=>['com']).must_be_nil
 
     login(:login=>'foo@h.com')
     page.find('#notice_flash').text.must_equal 'You have been logged in'


### PR DESCRIPTION
This allows the caller to pass additional custom parameters that are not known to Rodauth to internal requests. For example, if we've added an additional `name` field to the create account form for the user to enter their full name, we might want to pass the `name` parameter into the internal request as well. We can now do this via `:params`:

```rb
App.rodauth.create_account(
  login: "user@example.com",
  password: "secret",
  params: { "name" => "John Smith" }
)
```
