### PR TITLE
Use configured domain in email links and other URLs

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -448,7 +448,9 @@ module Rodauth
     end
 
     def base_url
-      request.base_url
+      url = "#{request.scheme}://#{domain}"
+      url << ":#{request.port}" if request.port != Rack::Request::DEFAULT_PORTS[request.scheme]
+      url
     end
 
     def domain

--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -234,6 +234,7 @@ module Rodauth
          "SCRIPT_NAME" => "",
          "HTTP_HOST" => INVALID_DOMAIN,
          "SERVER_NAME" => INVALID_DOMAIN,
+         "SERVER_PORT" => 443,
          "CONTENT_TYPE" => "application/x-www-form-urlencoded",
          "rack.input"=>StringIO.new(''),
          "rack.url_scheme"=>"https"

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -705,8 +705,29 @@ describe 'Rodauth' do
     page.find('#notice_flash').text.must_equal 'You have been logged in'
   end
 
+  it "should use domain when generating URLs" do
+    rodauth do
+      enable :login, :logout, :verify_account, :internal_request
+      domain "foo.com"
+      internal_request_configuration do
+        domain "bar.com"
+      end
+    end
+    roda do |r|
+      r.rodauth
+      view :content=>""
+    end
+
+    visit "/create-account"
+    fill_in "Login", with: "user@foo.com"
+    click_on "Create Account"
+    email_link(/http:\/\/foo\.com\/verify-account/, "user@foo.com")
+
+    app.rodauth.create_account(login: "user@bar.com")
+    email_link(/https:\/\/bar\.com\/verify-account/, "user@bar.com")
+  end
+
   it "should raise error unless domain is set" do
-    warning = nil
     rodauth do
       enable :login, :logout, :verify_account, :internal_request
     end


### PR DESCRIPTION
Rodauth allows configuring the domain via the `#domain` configuration method:

```rb
domain "example.com"
```

However, this domain wasn't used when generating full URLs via `#route_url`, because that uses `Rack::Request#base_url`, which reads the host from the rack env. This becomes an issue when using the internal_request feature, which sets the host in rack env to an invalid domain that is expected to be overridden. Setting the `#domain` gets rid of the error, but email links will still use the invalid placeholder domain.

This PR fixes the issue by modifying `#base_url` to use the configured domain. To retain backwards compatibility with proxies, we also change `#domain` to read from `Rack::Request#authority`, which is what `Rack::Request#base_url` reads from as well.

Let me know if you agree with this approach. I've also considered modifying the `env` hash with `#domain` value after instantiating the Rodauth instance in the `.internal_request` method. However, I felt that email links and other URLs should use the configured `#domain` even when not using the internal_request feature.
