### PR TITLE
Expose flash, reason, and field errors on InternalRequestError

### DIFF
--- a/doc/internal_request.rdoc
+++ b/doc/internal_request.rdoc
@@ -86,8 +86,10 @@ method inside configuration method blocks:
 Internal request methods ending in a question mark return true or false.
 Most other internal request methods return nil on success, and or raise a
 Rodauth::InternalRequestError exception on failure.  The exception
-message will be the {the reason for the failure}[rdoc-ref:doc/error_reasons.rdoc],
-as a string, in most cases.
+message will include the flash message, {the reason for the
+failure}[rdoc-ref:doc/error_reasons.rdoc] if available, and any field errors.
+This data can also be retrieved via +flash+, +reason+, and +field_errors+
+attributes on the exception object.
 
 If an internal request method returns a non-nil value on success,
 it will be documented in the Features section below. In such

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -744,6 +744,23 @@ describe 'Rodauth' do
     end.must_raise Rodauth::InternalRequestError
   end
 
+  it "should set attributes on internal request error" do
+    rodauth do
+      enable :create_account, :internal_request
+    end
+    roda do |r|
+    end
+
+    error = proc do
+      app.rodauth.create_account(login: "foo", password: "secret")
+    end.must_raise Rodauth::InternalRequestError
+
+    error.message.must_equal 'There was an error creating your account (login_not_valid_email, {"login"=>"invalid login, not a valid email address"})'
+    error.flash.must_equal "There was an error creating your account"
+    error.reason.must_equal :login_not_valid_email
+    error.field_errors.must_equal({ "login" => "invalid login, not a valid email address" })
+  end
+
   it "should allow checking whether an account exists using internal requests" do
     rodauth do
       enable :internal_request


### PR DESCRIPTION
To give the user all available information about why an internal request failed, we include flash, reason, and field errors in the exception message, and also expose this data via attributes on the exception object.