### PR TITLE
Implement `#lock_account` without setting `@account`

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -199,8 +199,7 @@ module Rodauth
     end
 
     def _handle_lock_account(_)
-      @account = {account_id_column=>session_value}
-      raised_uniqueness_violation{account_lockouts_ds.insert(_setup_account_lockouts_hash(account_id, generate_unlock_account_key))}
+      raised_uniqueness_violation{account_lockouts_ds(session_value).insert(_setup_account_lockouts_hash(session_value, generate_unlock_account_key))}
     end
 
     def _handle_remember_setup(request)


### PR DESCRIPTION
This is a really small thing, but I noticed that `#lock_account` in internal_request feature can be implemented without setting `@account` (at least without any test failures), so I thought it's worth the change.
