### PR TITLE
Make internal requests work in JSON-only mode

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -92,6 +92,10 @@ module Rodauth
       @internal_request_return_value
     end
 
+    def only_json?
+      false
+    end
+
     private
 
     def internal_request?

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -151,4 +151,16 @@ describe 'Rodauth json feature' do
     res = json_request('/login', :login=>'foo@example.com')
     res.must_equal [200, {}]
   end
+
+  it "should work with internal requests if only_json? is true" do
+    rodauth do
+      enable :login, :create_account, :internal_request, :json
+      only_json? true
+    end
+    roda(:json=>true) do |r|
+      r.rodauth
+    end
+    app.rodauth.create_account(:login=>'bar@example.com', :password=>'secret')
+    app.rodauth.valid_login_and_password?(:login=>'bar@example.com', :password=>'secret').must_equal true
+  end
 end


### PR DESCRIPTION
When `#only_json?` is set to true, the JSON feature requires that requests have `Content-Type` and `Accept` headers set to JSON. This is not the case in internal requests, which have a form-data content type set up.

Since in internal requests we don't want to deal with HTTP-level requirements, we set `#only_json?` to false in the internal auth class to allow non-JSON requests. This should be fine, because in internal requests params are grabbed from an internal hash anyway.
