### PR TITLE
Set error status in verification request response

### DIFF
--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -274,7 +274,7 @@ module Rodauth
 
     def before_login_attempt
       unless open_account?
-        set_redirect_error_status(unopen_account_error_status)
+        set_response_error_status(unopen_account_error_status)
         set_error_reason :unverified_account
         set_error_flash attempt_to_login_to_unverified_account_error_flash
         response.write resend_verify_account_view

--- a/spec/verify_account_spec.rb
+++ b/spec/verify_account_spec.rb
@@ -32,6 +32,7 @@ describe 'Rodauth verify_account feature' do
     login(:login=>'foo@example2.com')
     page.find('#error_flash').text.must_equal 'The account you tried to login with is currently awaiting verification'
     page.html.must_include("If you no longer have the email to verify the account, you can request that it be resent to you")
+    page.status_code.must_equal 403
     click_button 'Send Verification Email Again'
     page.current_path.must_equal '/'
     email_link(/(\/verify-account\?key=.+)$/, 'foo@example2.com').must_equal link


### PR DESCRIPTION
When attempting to login to an unverified account, it causes the form for resending verification email was displayed, and currently the response status is 200 OK. This was probably unintentional, because Rodauth generally uses 4xx status codes to render error responses.

So, we change this response to use a 4xx status code as well. This improves compatibility with Turbo, which expects form submits to either redirect or return a non-2xx status code.
