### PR TITLE
Return error status when unverified account exists on account creation

### DIFF
--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -196,8 +196,7 @@ module Rodauth
 
     def new_account(login)
       if account_from_login(login) && allow_resending_verify_account_email?
-        set_redirect_error_status(unopen_account_error_status)
-        set_error_reason :already_an_unverified_account_with_this_login
+        set_response_error_reason_status(:already_an_unverified_account_with_this_login, unopen_account_error_status)
         set_error_flash attempt_to_create_unverified_account_error_flash
         response.write resend_verify_account_view
         request.halt
@@ -274,8 +273,7 @@ module Rodauth
 
     def before_login_attempt
       unless open_account?
-        set_response_error_status(unopen_account_error_status)
-        set_error_reason :unverified_account
+        set_response_error_reason_status(:unverified_account, unopen_account_error_status)
         set_error_flash attempt_to_login_to_unverified_account_error_flash
         response.write resend_verify_account_view
         request.halt

--- a/spec/lockout_spec.rb
+++ b/spec/lockout_spec.rb
@@ -37,6 +37,7 @@ describe 'Rodauth lockout feature' do
     click_button 'Login'
     page.find('#error_flash').text.must_equal "This account is currently locked out and cannot be logged in to"
     page.body.must_include("This account is currently locked out")
+    page.status_code.must_equal 403
     click_button 'Request Account Unlock'
     page.find('#notice_flash').text.must_equal 'An email has been sent to you with a link to unlock your account'
     link = email_link(/(\/unlock-account\?key=.+)$/)

--- a/spec/verify_account_spec.rb
+++ b/spec/verify_account_spec.rb
@@ -74,6 +74,9 @@ describe 'Rodauth verify_account feature' do
     visit '/create-account'
     fill_in 'Login', :with=>'foo@example2.com'
     click_button 'Create Account'
+    page.find('#error_flash').text.must_equal "The account you tried to create is currently awaiting verification"
+    page.html.must_include("If you no longer have the email to verify the account, you can request that it be resent to you")
+    page.status_code.must_equal 403
     click_button 'Send Verification Email Again'
     page.find('#notice_flash').text.must_equal "An email has been sent to you with a link to verify your account"
     page.current_path.must_equal '/'


### PR DESCRIPTION
In #177 I missed another place in verify_account where error status should be set, which is when an unverified account exists when attempting to create an account.

I've switched to using `#set_response_error_reason_status`, as that's used in most other places. I've also added a test for the lockout feature that asserts that a 4xx response status is set when showing the lockout page.
