### PR TITLE
Fix link to path_class_methods plugin

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -40,7 +40,7 @@
   <li><a href="rdoc/files/doc/password_expiration_rdoc.html">Password Expiration</a>: Requires that accounts change their password after a given amount of time.</li>
   <li><a href="rdoc/files/doc/password_grace_period_rdoc.html">Password Grace Period</a>: Allows skipping password entry on forms normally requiring it if a user recently entered their password.</li>
   <li><a href="rdoc/files/doc/password_pepper_rdoc.html">Password Pepper</a>: Allows appending a secret key to passwords before they are hashed.</li>
-  <li><a href="rdoc/files/doc/path_class_methods.html">Path Class Methods</a>: Allows for getting paths/URLs for features using class methods.</li>
+  <li><a href="rdoc/files/doc/path_class_methods_rdoc.html">Path Class Methods</a>: Allows for getting paths/URLs for features using class methods.</li>
   <li><a href="rdoc/files/doc/recovery_codes_rdoc.html">Recovery Codes</a>: Adds support for mulitfactor authentication via single-use account recovery codes.</li>
   <li><a href="rdoc/files/doc/remember_rdoc.html">Remember</a>: Automatically logs a user in based on a token stored in a cookie.</li>
   <li><a href="rdoc/files/doc/reset_password_rdoc.html">Reset Password</a>: Allows users to reset their password if they don't remember it.</li>


### PR DESCRIPTION
It was missing the `_rdoc` suffix.
