### PR TITLE
Set configuration name for provided auth classes

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -50,13 +50,14 @@ module Rodauth
     else
       json_opt != :only
     end
-    auth_class = (app.opts[:rodauths] ||= {})[opts[:name]] ||= opts[:auth_class] || Class.new(Auth){@configuration_name = opts[:name]}
+    auth_class = (app.opts[:rodauths] ||= {})[opts[:name]] ||= opts[:auth_class] || Class.new(Auth)
     if !auth_class.roda_class
       auth_class.roda_class = app
     elsif auth_class.roda_class != app
-      auth_class = app.opts[:rodauths][opts[:name]] = Class.new(auth_class){@configuration_name = opts[:name]}
+      auth_class = app.opts[:rodauths][opts[:name]] = Class.new(auth_class)
       auth_class.roda_class = app
     end
+    auth_class.class_eval{@configuration_name = opts[:name]}
     auth_class.configure(&block) if block
   end
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -113,6 +113,33 @@ describe 'Rodauth' do
     auth_class.features.must_include :login
   end
 
+  it "should set configuration name for anonymous classes" do
+    @no_precompile = true
+    rodauth do
+      enable :login
+    end
+    roda(name: :admin) do |r|
+      r.rodauth
+    end
+
+    @app.rodauth(:admin).configuration_name.must_equal :admin
+  end
+
+  it "should set configuration name for provided auth classes" do
+    require "rodauth"
+
+    auth_class = Class.new(Rodauth::Auth)
+    @no_precompile = true
+    rodauth do
+      enable :login
+    end
+    roda(auth_class: auth_class, name: :admin) do |r|
+      r.rodauth
+    end
+
+    auth_class.configuration_name.must_equal :admin
+  end
+
   it "should not require passing a block when loading the plugin" do
     app = Class.new(Base)
     app.plugin :rodauth


### PR DESCRIPTION
This ensures that auth classes that have been defined explicitly will also have configuration name assigned, just like anonymous classes.

I came across this when building an i18n integration, which uses the configuration name for translation namespaces.
