### PR TITLE
Assign internal request subclass to a constant

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -366,6 +366,11 @@ module Rodauth
           end
         end
       end
+
+      if klass.name
+        klass.const_set(:InternalRequest, internal_class)
+        klass.private_constant :InternalRequest
+      end
     end
   end
 end

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -733,6 +733,24 @@ describe 'Rodauth' do
     page.find('#notice_flash').text.must_equal 'You have been logged in'
   end
 
+  it "should assign internal request subclass to a constant" do
+    require "rodauth"
+
+    Object.const_set(:RodauthMain, Class.new(Rodauth::Auth))
+    rodauth do
+      enable :internal_request
+    end
+    roda(auth_class: RodauthMain) do |r|
+      r.rodauth
+    end
+
+    instance = RodauthMain.internal_request_eval { self }
+    instance.class.name.must_equal "RodauthMain::InternalRequest"
+    instance.class.superclass.must_equal RodauthMain
+
+    Object.send(:remove_const, :RodauthMain)
+  end
+
   it "should use domain when generating URLs" do
     rodauth do
       enable :login, :logout, :verify_account, :internal_request


### PR DESCRIPTION
For named auth classes, internal request subclass is still anonymous:

```rb
class RodauthMain < Rodauth::Auth
end

class RodauthApp < Roda
  plugin :rodauth, auth_class: RodauthMain do
    enable :internal_request
  end
end

RodauthMain.internal_request_eval do
  self.class #=> #<Class:0x0000000143b57680>
end
```

I thought it would be nice for introspection and error messages if the internal subclass was assigned into a constant for named auth classes. With the changes in this pull request, we now have:

```rb
RodauthMain.internal_request_eval do
  self.class #=> RodauthMain::InternalRequest
end
```

This is especially useful with rodauth-rails, which exposes an `instance` class method that returns an internal request instance:

```rb
rodauth = RodauthMain.instance
rodauth #=> #<RodauthMain::InternalRequest ...>
```

We make the constant private to ensure it stays internal.
