### PR TITLE
Remove duplicate word in Reporting Bugs section of website and mention GitHub Discussions in a couple more places

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -39,7 +39,7 @@ Pull Request Guidelines
    be merged.  Pull requests should not be used to "start a
    convervation" about a possible code change.  If the pull
    request requires a conversation, that conversation should take
-   place on the rodauth Google Group.
+   place on GitHub Discussions or the rodauth Google Group.
 
 7) Pull requests are generally closed as soon as it appears that the
    branch will not be merged.  However, discussion about the code can

--- a/www/pages/development.erb
+++ b/www/pages/development.erb
@@ -1,6 +1,6 @@
 <h2>Development</h2>
 
-<p>Rodauth, while a mature framework, is still under active development.  You can join in on the discussions, ask questions, suggest features, and discuss Rodauth in general by joining the <a href='http://groups.google.com/group/rodauth'>rodauth Google Group</a>.</p>
+<p>Rodauth, while a mature framework, is still under active development.  You can join in on the discussions, ask questions, suggest features, and discuss Rodauth in general on <a href="https://github.com/jeremyevans/rodauth/discussions">GitHub Discussions</a> or by joining the <a href='http://groups.google.com/group/rodauth'>rodauth Google Group</a>.</p>
 
 <h3>Reporting Bugs</h3>
 

--- a/www/pages/development.erb
+++ b/www/pages/development.erb
@@ -4,7 +4,7 @@
 
 <h3>Reporting Bugs</h3>
 
-<p>To report a bug in Rodauth, use <a href="https://github.com/jeremyevans/rodauth/issues">GitHub Issues</a>.  If you aren't sure if something is a bug, post a question on on <a href="https://github.com/jeremyevans/rodauth/discussions">GitHub Discussions</a> or the <a href='http://groups.google.com/group/rodauth'>Google Group</a>.  Note that GitHub Issues should not be used to ask questions about how to use Rodauth; use GitHub Discussions or the Google Group for that.</p>
+<p>To report a bug in Rodauth, use <a href="https://github.com/jeremyevans/rodauth/issues">GitHub Issues</a>.  If you aren't sure if something is a bug, post a question on <a href="https://github.com/jeremyevans/rodauth/discussions">GitHub Discussions</a> or the <a href='http://groups.google.com/group/rodauth'>Google Group</a>.  Note that GitHub Issues should not be used to ask questions about how to use Rodauth; use GitHub Discussions or the Google Group for that.</p>
 
 <h3>Source Code</h3>
 


### PR DESCRIPTION
This PR just fixes a minor typo from 36d7c7ad6276f6a4631dced58c6750c4776a4638