### PR TITLE
Support multi-level inheritance

### DIFF
--- a/doc/guides/share_configuration.rdoc
+++ b/doc/guides/share_configuration.rdoc
@@ -1,0 +1,30 @@
+= Share configuration via inheritance
+
+If you have multiple configurations that needs to share some amount of
+authentication behaviour, you can do so through inheritance. For example:
+
+  require "rodauth"
+
+  class RodauthBase < Rodauth::Auth
+    configure do
+      # common authentication configuration
+    end
+  end
+
+  class RodauthMain < RodauthBase # inherit common configuration
+    configure do
+      # main-specific authentication configuration
+    end
+  end
+
+  class RodauthAdmin < RodauthBase # inherit common configuration
+    configure do
+      # admin-specific authentication configuration
+    end
+  end
+
+  class RodauthApp < Roda
+    plugin :rodauth, auth_class: RodauthMain
+    plugin :rodauth, auth_class: RodauthAdmin, name: :admin
+    # ...
+  end

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -284,11 +284,14 @@ module Rodauth
 
     def self.inherited(subclass)
       super
+      superclass = self
       subclass.instance_exec do
-        @features = []
-        @routes = []
-        @route_hash = {}
-        @configuration = Configuration.new(self)
+        @roda_class = superclass.roda_class
+        @features = superclass.features.clone || []
+        @routes = superclass.routes.clone || []
+        @route_hash = superclass.route_hash.clone || {}
+        @configuration = superclass.configuration.clone || Configuration.new(self)
+        @configuration.instance_variable_set(:@auth, self)
       end
     end
 

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -284,13 +284,13 @@ module Rodauth
 
     def self.inherited(subclass)
       super
-      superclass = self
+      klass = self
       subclass.instance_exec do
-        @roda_class = superclass.roda_class
-        @features = superclass.features.clone || []
-        @routes = superclass.routes.clone || []
-        @route_hash = superclass.route_hash.clone || {}
-        @configuration = superclass.configuration.clone || Configuration.new(self)
+        @roda_class = klass.roda_class
+        @features = klass.features ? klass.features.clone : []
+        @routes = klass.routes ? klass.routes.clone : []
+        @route_hash = klass.route_hash ? klass.route_hash.clone : {}
+        @configuration = klass.configuration ? klass.configuration.clone : Configuration.new(self)
         @configuration.instance_variable_set(:@auth, self)
       end
     end

--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -339,14 +339,7 @@ module Rodauth
       return if is_a?(InternalRequestMethods)
 
       klass = self.class
-      internal_class = Class.new(klass) do
-        @roda_class = klass.roda_class
-        @features = klass.features.clone
-        @routes = klass.routes.clone
-        @route_hash = klass.route_hash.clone
-        @configuration = klass.configuration.clone
-        @configuration.instance_variable_set(:@auth, self)
-      end
+      internal_class = Class.new(klass)
 
       if blocks = klass.instance_variable_get(:@internal_request_configuration_blocks)
         configuration = internal_class.configuration

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -77,6 +77,7 @@
   <li><a href="rdoc/files/doc/guides/registration_field_rdoc.html">Add field during account creation</a></li>
   <li><a href="rdoc/files/doc/guides/require_mfa_rdoc.html">Require multifactor authentication after login</a></li>
   <li><a href="rdoc/files/doc/guides/reset_password_autologin_rdoc.html">Autologin after password reset</a></li>
+  <li><a href="rdoc/files/doc/guides/share_configuration_rdoc.html">Share configuration via inheritance</a></li>
   <li><a href="rdoc/files/doc/guides/status_column_rdoc.html">Store account status in a text column</a></li>
   <li><a href="rdoc/files/doc/guides/totp_or_recovery_rdoc.html">Allow recovery code on TOTP code field</a></li>
   <li><a href="rdoc/files/doc/guides/internals_rdoc.html">Internals Guide, describing how Rodauth works internally</a></li>


### PR DESCRIPTION
I've initially suggested this in #151, where we instead ended up making minimal changes that allowed rodauth-rails to support multi-level inheritance. With the support of named auth classes (which rodauth-rails 1.0 will now generate by default), I wanted to make another attempt at supporting multi-level inheritance in Rodauth itself. I think it's a pretty convenient way to share common configuration, and I thought it would be nice for Rodauth to provide this convenience out-of-the-box.

The internal_request feature already implements this functionality, so here we're just moving that into the core. Unlike my original attempt, here I didn't change any attribute readers/writers/accessors, nor assigned instance variables directly on the `Rodauth::Auth` class.
