### PR TITLE
Fix spelling of global_logout_label default in active_sessions feature

### DIFF
--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -13,7 +13,7 @@ module Rodauth
     auth_value_method :active_sessions_last_use_column, :last_use
     auth_value_method :active_sessions_session_id_column, :session_id
     auth_value_method :active_sessions_table, :account_active_session_keys
-    translatable_method :global_logout_label, 'Logout all Logged In Sessons?'
+    translatable_method :global_logout_label, 'Logout all Logged In Sessions?'
     auth_value_method :global_logout_param, 'global_logout'
     auth_value_method :inactive_session_error_status, 401
     auth_value_method :session_inactivity_deadline, 86400

--- a/spec/active_sessions_spec.rb
+++ b/spec/active_sessions_spec.rb
@@ -218,7 +218,7 @@ describe 'Rodauth active sessions feature' do
     page.body.must_equal session_id2
 
     visit '/logout'
-    check 'global-logout'
+    check 'Logout all Logged In Sessions?'
     click_button 'Logout'
 
     remove_cookie('rack.session')


### PR DESCRIPTION
Noticed this while adding active_sessions to a project. This seemed minor enough that we don't need to add a spec for it but I can if you think we should!