### PR TITLE
Clear session when unverified grace period expired on require login

### DIFF
--- a/spec/verify_account_grace_period_spec.rb
+++ b/spec/verify_account_grace_period_spec.rb
@@ -324,4 +324,31 @@ describe 'Rodauth verify_account_grace_period feature' do
     email_link(/(\/verify-account\?key=.+)$/, 'foo@example2.com')
     page.body.must_include('Authenticated? true')
   end
+
+  it "should clear the session when unverified grace period expired on required login" do
+    rodauth do
+      enable :verify_account_grace_period
+      verify_account_set_password? true
+    end
+    roda do |r|
+      r.rodauth
+      rodauth.require_login if rodauth.logged_in?
+      r.root{view :content=>"Authenticated? #{!!rodauth.logged_in?}"}
+      r.get('expire') do
+        session[rodauth.unverified_account_session_key] -= 100000
+        r.redirect '/'
+      end
+    end
+
+    visit '/create-account'
+    fill_in 'Login', :with=>'foo@example2.com'
+    click_button 'Create Account'
+    page.find('#notice_flash').text.must_equal "An email has been sent to you with a link to verify your account"
+    email_link(/(\/verify-account\?key=.+)$/, 'foo@example2.com')
+    page.body.must_include('Authenticated? true')
+
+    visit '/expire'
+    page.current_path.must_equal '/login'
+    page.find('#error_flash').text.must_equal "Please login to continue"
+  end
 end


### PR DESCRIPTION
*Follow-up to the discussion in https://github.com/jeremyevans/rodauth/discussions/210*

Currently a user whose unverified grace period expired can still continue to browse the application, as long as they don't close their browser or visit any authentication routes.

We address that by adding the grace period expiration to the session, and logging the user out when it has expired. By storing this in session, we avoid a database query on each call to require_login. We maintain backwards compatibility with existing session values still set to `true`.