### PR TITLE
Make `#require_account` method public

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -990,6 +990,10 @@ require_authentication :: Similar to +require_login+, but also requires
                           two factor authentication.  Redirects the request to
                           the two factor authentication page if logged in but not
                           authenticated via two factors.
+require_account :: Similar to +require_authentication+, but also loads the logged
+                   in account to ensure it exists in the database.  If the account
+                   doesn't exist, or if it exists but isn't verified, the session
+                   is cleared and the request redirected to the login page.
 logged_in? :: Whether the session has been logged in.
 authenticated? :: Similar to +logged_in?+, but if the account has setup two
                   factor authentication, whether the session has authenticated

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -338,6 +338,11 @@ module Rodauth
       require_login
     end
 
+    def require_account
+      require_authentication
+      require_account_session
+    end
+
     def account_initial_status_value
       account_open_status_value
     end
@@ -522,11 +527,6 @@ module Rodauth
     def timing_safe_eql?(provided, actual)
       provided = provided.to_s
       Rack::Utils.secure_compare(provided.ljust(actual.length), actual) && provided.length == actual.length
-    end
-
-    def require_account
-      require_authentication
-      require_account_session
     end
 
     def require_account_session


### PR DESCRIPTION
*Follow-up to the discussion in https://github.com/jeremyevans/rodauth/discussions/210*

This allows ensuring the account exists in the database before proceeding with the request. This is useful for preventing errors in development when the account record has been manually deleted, or if the account record has been deleted in production for whatever reason, and the performance impact of fetching the account record on each request is acceptable.
