### PR TITLE
Avoid extra bcrypt hashing on account verification when using password hash column

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -756,7 +756,7 @@ module Rodauth
       num = ds.update(values)
       if num == 1
         values.each do |k, v|
-          account[k] = v == Sequel::CURRENT_TIMESTAMP ? Time.now : v
+          account[k] = Sequel::CURRENT_TIMESTAMP == v ? Time.now : v
         end
       end
       num


### PR DESCRIPTION
If Rodauth is configured to use a password hash column on the accounts table, and to require password on account verification, there is an extra bcrypt hashing that occurs while updating the account hash in memory after updating it in the database.

Because the values used to update the account will contain a `BCrypt::Password` object, and `BCrypt::Password#==` will perform password hashing on the right-hand operand (even for non-string operands), the comparison with `Sequel::CURRENT_TIMESTAMP` will cause it to be hashed, using the same cost that password hashing uses. I found this out when profiling an account verification request that was taking 500ms+ locally, which seemed too long for a default password hash cost.

We fix that by using `Object#equal?`, which compares object ids directly, and is not overridden by `BCrypt::Password`.
