### PR TITLE
Fix bug with update_hash_ds

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -756,7 +756,7 @@ module Rodauth
       num = ds.update(values)
       if num == 1
         values.each do |k, v|
-          account[k] = Sequel::CURRENT_TIMESTAMP == v ? Time.now : v
+          hash[k] = Sequel::CURRENT_TIMESTAMP == v ? Time.now : v
         end
       end
       num


### PR DESCRIPTION
I'm surprised there wasn't a test that caught this for the `sms_codes` feature, which uses it thusly:

https://github.com/jeremyevans/rodauth/blob/d21277ddaae0b74ba70c86a8f08f467344085f76/lib/rodauth/features/sms_codes.rb#L495-L497