### PR TITLE
Update paths.rdoc guide to include use of `require_login_redirect`

### DIFF
--- a/doc/guides/paths.rdoc
+++ b/doc/guides/paths.rdoc
@@ -8,6 +8,9 @@ corresponding <tt>*_route</tt> method:
 
     # Change login route to "/signin"
     login_route "signin"
+    
+    # Change redirect when login is required to "/signin"
+    require_login_redirect { login_path }
 
     # Change create account route to "/register"
     create_account_route "register"


### PR DESCRIPTION
When changing `login_route` as prescribed in the guide, developers of non API only apps will likely want to also update `require_login_redirect`. I was looking into whether this was a rodauth-rails specific issue, but I am not familiar enough to tell, and will leave this as draft.