### PR TITLE
Change Rails project references into links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1495,9 +1495,10 @@ required to run the current version of Rodauth is 1.9.2.
 
 All of these are Rails-specific:
 
-* Devise
-* Authlogic
-* Sorcery
+* Devise :: https://github.com/heartcombo/devise
+* Authlogic :: https://github.com/binarylogic/authlogic
+* Sorcery :: https://github.com/Sorcery/sorcery
+* rodauth-rails :: https://github.com/janko/rodauth-rails
 
 == Author
 


### PR DESCRIPTION
I also added @janko's project. I thought I'd save my fellow Rails devs researching authentication options a couple of seconds to find information about these projects. With any luck, this PR will collectively save humanity a couple of hours for doing (hopefully) more important things. :)

As you can see from my local repo, I am obviously kind of terrible at this stuff which is why I probably just do safe stuff like READMEs hahaha.