### PR TITLE
Extract request halting into `#return_response` method

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -511,6 +511,11 @@ module Rodauth
       request.redirect(path)
     end
 
+    def return_response(body=nil)
+      response.write(body) if body
+      request.halt
+    end
+
     def route_path(route, opts={})
       path  = "#{prefix}/#{route}"
       path += "?#{Rack::Utils.build_nested_query(opts)}" unless opts.empty?

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -27,7 +27,7 @@ module Rodauth
     def require_http_basic_auth
       unless http_basic_auth
         set_http_basic_auth_error_response
-        request.halt
+        return_response
       end
     end
 

--- a/lib/rodauth/features/json.rb
+++ b/lib/rodauth/features/json.rb
@@ -156,8 +156,7 @@ module Rodauth
         end
       elsif only_json?
         response.status = json_response_error_status
-        response.write non_json_request_error_message
-        request.halt
+        return_response non_json_request_error_message
       end
 
       super
@@ -175,8 +174,7 @@ module Rodauth
     def _return_json_response
       response.status ||= json_response_error_status if json_response[json_response_error_key]
       response['Content-Type'] ||= json_response_content_type
-      response.write(_json_response_body(json_response))
-      request.halt
+      return_response _json_response_body(json_response)
     end
 
     def include_success_messages?

--- a/lib/rodauth/features/jwt_cors.rb
+++ b/lib/rodauth/features/jwt_cors.rb
@@ -41,7 +41,7 @@ module Rodauth
           response['Access-Control-Allow-Headers'] = jwt_cors_allow_headers
           response['Access-Control-Max-Age'] = jwt_cors_max_age.to_s
           response.status = 204
-          request.halt(response.finish)
+          return_response
         end
 
         response['Access-Control-Expose-Headers'] = jwt_cors_expose_headers

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -277,8 +277,7 @@ module Rodauth
     def show_lockout_page
       set_response_error_reason_status(:account_locked_out, lockout_error_status)
       set_error_flash login_lockout_error_flash
-      response.write unlock_account_request_view
-      request.halt
+      return_response unlock_account_request_view
     end
 
     def unlock_account_email_recently_sent?

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -195,8 +195,7 @@ module Rodauth
       if account_from_login(login) && allow_resending_verify_account_email?
         set_response_error_reason_status(:already_an_unverified_account_with_this_login, unopen_account_error_status)
         set_error_flash attempt_to_create_unverified_account_error_flash
-        response.write resend_verify_account_view
-        request.halt
+        return_response resend_verify_account_view
       end
       super
     end
@@ -268,8 +267,7 @@ module Rodauth
       unless open_account?
         set_response_error_reason_status(:unverified_account, unopen_account_error_status)
         set_error_flash attempt_to_login_to_unverified_account_error_flash
-        response.write resend_verify_account_view
-        request.halt
+        return_response resend_verify_account_view
       end
       super
     end


### PR DESCRIPTION
This change allows libraries integrating with Rodauth to react on thrown responses by overriding `#return_response` and `#redirect`. It also makes the code a bit DRYer.

I would like to use this in rodauth-rails. Currently, when a Rodauth method that redirects or otherwise returns a response is called from within a Rails controller, the response status is missing from Action Controller's instrumentation output. With this change, rodauth-rails' `rails` feature can override `#redirect` and `#return_response` to save the response status, and assign it for instrumentation.

<details>
<summary>rodauth-rails change</summary>

```diff
diff --git a/lib/rodauth/rails/controller_methods.rb b/lib/rodauth/rails/controller_methods.rb
index 0d80fc0..9114aa3 100644
--- a/lib/rodauth/rails/controller_methods.rb
+++ b/lib/rodauth/rails/controller_methods.rb
@@ -16,6 +16,13 @@ module Rodauth
         request.env.fetch ["rodauth", *name].join(".")
       end
 
+      def append_info_to_payload(payload)
+        super
+        if request.env["rodauth.rails.status"]
+          payload[:status] = request.env["rodauth.rails.status"]
+        end
+      end
+
       private
 
       def rodauth_response
diff --git a/lib/rodauth/rails/feature/instrumentation.rb b/lib/rodauth/rails/feature/instrumentation.rb
index beba6b9..9d86268 100644
--- a/lib/rodauth/rails/feature/instrumentation.rb
+++ b/lib/rodauth/rails/feature/instrumentation.rb
@@ -10,6 +10,14 @@ module Rodauth
 
         def redirect(*)
           rails_instrument_redirection { super }
+        ensure
+          request.env["rodauth.rails.status"] = response.status
+        end
+
+        def return_response(*)
+          super
+        ensure
+          request.env["rodauth.rails.status"] = response.status
         end
 
         def rails_render(*)
```

Before:

```
Started GET "/posts" for ::1 at 2022-03-25 14:16:27 +0100
Processing by PostsController#index as HTML
Redirected to /login
Completed   in 4ms (ActiveRecord: 0.0ms | Allocations: 5568)
```

After:

```
Started GET "/posts" for ::1 at 2022-03-25 14:16:39 +0100
Processing by PostsController#index as HTML
Redirected to /login
Completed 302 Found in 1ms (ActiveRecord: 0.0ms | Allocations: 338)
```
</details>
