### PR TITLE
Fix removing all MFA methods not removing SMS session

### DIFF
--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -468,7 +468,7 @@ module Rodauth
     end
 
     def _two_factor_remove_all_from_session
-      two_factor_remove_session('sms_codes')
+      two_factor_remove_session('sms_code')
       super
     end
 


### PR DESCRIPTION
On SMS setup and authentication, `sms_code` is added to the list of methods the session is authenticated by. However, when removing all multifactor authentication methods, Rodauth is removing `sms_codes` method, which will cause the account authenticated via SMS to stay SMS authenticated. We fix that by removing `sms_code` method instead.

The method deletion from session when removing all MFA methods wasn't tested for any MFA method (except implicitly for recovery codes), so we add the missing tests.
