### PR TITLE
Ensure WebAuthn tests run on Ruby 3.1

### DIFF
--- a/.ci.gemfile
+++ b/.ci.gemfile
@@ -86,6 +86,9 @@ platforms :ruby do
   elsif RUBY_VERSION > '2.3'
     gem 'webauthn', '<2.2.0'
   end
+  if RUBY_VERSION > '2.3'
+    gem 'openssl', '~> 2.0'
+  end
 end
 
 if RUBY_VERSION < '2.3'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 $: << 'lib'
 
 begin
-  # Needed for Ruby 2.3 and webauthn, which requires openssl gem > 2
-  gem "openssl", '>2' if RUBY_VERSION < '2.4'
+  # Needed for Ruby 2.3 and webauthn, which requires openssl gem > 2, and for
+  # webauthn gem not yet supporting openssl gem version 3.
+  gem "openssl", '~> 2.0' if RUBY_VERSION > '2.3'
 rescue LoadError
 end
 


### PR DESCRIPTION
Ruby 3.1 ships with OpenSSL 3.0 as the default gem, but WebAuthn gem don't support OpenSSL 3.0 yet, which caused WebAuthn tests to be skipped. To work around that, we make sure to install OpenSSL 2.x and require it for now.
