### PR TITLE
Add `#otp_available?` and `#recovery_codes_available?` auth methods

### DIFF
--- a/doc/otp.rdoc
+++ b/doc/otp.rdoc
@@ -70,6 +70,7 @@ before_otp_setup_route :: Run arbitrary code before handling an OTP authenticati
 otp :: The object used for verifying OTP authentication attempts.
 otp_add_key(secret) :: Add an OTP key for the current account with the given secret.
 otp_auth_view :: The HTML to use for the OTP authentication form.
+otp_available? :: Whether OTP authentication is ready for use.
 otp_disable_view :: The HTML to use for the OTP disable form.
 otp_exists? :: Whether the current account has setup OTP.
 otp_key :: The stored OTP secret for the account.

--- a/doc/recovery_codes.rdoc
+++ b/doc/recovery_codes.rdoc
@@ -57,4 +57,5 @@ new_recovery_code :: A new recovery code to insert into the recovery codes table
 recovery_auth_view :: The HTML to use for the form to authenticate via a recovery code.
 recovery_code_match?(code) :: Whether the given code matches any of the existing recovery_codes.
 recovery_codes :: An array containing all valid recovery codes for the current account.
+recovery_codes_available? :: Whether authentication via recovery codes is ready for use.
 recovery_codes_view :: The HTML to use for the form to view recovery codes.

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -76,6 +76,7 @@ module Rodauth
     )
 
     auth_methods(
+      :otp_available?,
       :otp_exists?,
       :otp_last_use,
       :otp_locked_out?,
@@ -238,6 +239,10 @@ module Rodauth
       end
     end
 
+    def otp_available?
+      otp_exists? && !otp_locked_out?
+    end
+
     def otp_exists?
       !otp_key.nil?
     end
@@ -328,7 +333,7 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [20, otp_auth_path, otp_auth_link_text] if otp_exists? && !otp_locked_out?
+      links << [20, otp_auth_path, otp_auth_link_text] if otp_available?
       links
     end
 

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -57,6 +57,7 @@ module Rodauth
       :can_add_recovery_codes?,
       :new_recovery_code,
       :recovery_code_match?,
+      :recovery_codes_available?,
     )
 
     internal_request_method :recovery_codes
@@ -192,6 +193,10 @@ module Rodauth
       end
     end
 
+    def recovery_codes_available?
+      !recovery_codes_ds.empty?
+    end
+
     def possible_authentication_methods
       methods = super
       methods << 'recovery_code' unless recovery_codes_ds.empty?
@@ -202,7 +207,7 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [40, recovery_auth_path, recovery_auth_link_text] unless recovery_codes_ds.empty?
+      links << [40, recovery_auth_path, recovery_auth_link_text] if recovery_codes_available?
       links
     end
 

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -430,7 +430,7 @@ module Rodauth
     end
 
     def sms_available?
-      sms && !sms_needs_confirmation? && !sms_locked_out?
+      sms_setup? && !sms_locked_out?
     end
 
     def sms_locked_out?


### PR DESCRIPTION
This is symmetrical to the `#sms_available?` method from the sms_codes feature. These methods should make it easier for the developer to manually generate authentication links, for cases when they cannot use `#two_factor_auth_links`.

In my case, I wanted that requiring multifactor authentication always redirects to the OTP auth page, and that links for authenticating via SMS or recovery code are displayed below the form. This way I would eliminate an additional click needed to get to the recommended MFA page (assuming TOTP is the primary method).

```erb
<!-- otp auth form -->
<% if rodauth.recovery_codes_available? %>
  <%= link_to "Authenticate Using Recovery Code", rodauth.recovery_auth_path %>
<% end %>
<% if rodauth.sms_available? %>
  <%= link_to "Authenticate Using SMS Code", rodauth.sms_request_path, data: { turbo_method: :post } %>
<% end %>
```

While here, I DRYed up `#sms_available?` a bit by having it call `#sms_setup?`.
