### PR TITLE
Allow passing token keys to `*_email_link` methods

### DIFF
--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -134,8 +134,8 @@ module Rodauth
       @account = _account_from_email_auth_key(key)
     end
 
-    def email_auth_email_link
-      token_link(email_auth_route, email_auth_key_param, email_auth_key_value)
+    def email_auth_email_link(key=email_auth_key_value)
+      token_link(email_auth_route, email_auth_key_param, key)
     end
 
     def get_email_auth_key(id)

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -223,8 +223,8 @@ module Rodauth
       @account = _account_from_unlock_key(key)
     end
 
-    def unlock_account_email_link
-      token_link(unlock_account_route, unlock_account_key_param, unlock_account_key_value)
+    def unlock_account_email_link(key=unlock_account_key_value)
+      token_link(unlock_account_route, unlock_account_key_param, key)
     end
 
     def get_unlock_account_email_last_sent

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -184,8 +184,8 @@ module Rodauth
       @account = _account_from_reset_password_key(key)
     end
 
-    def reset_password_email_link
-      token_link(reset_password_route, reset_password_key_param, reset_password_key_value)
+    def reset_password_email_link(key=reset_password_key_value)
+      token_link(reset_password_route, reset_password_key_param, key)
     end
 
     def get_password_reset_key(id)

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -208,8 +208,8 @@ module Rodauth
       account_unverified_status_value
     end
 
-    def verify_account_email_link
-      token_link(verify_account_route, verify_account_key_param, verify_account_key_value)
+    def verify_account_email_link(key=verify_account_key_value)
+      token_link(verify_account_route, verify_account_key_param, key)
     end
 
     def get_verify_account_key(id)

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -127,8 +127,8 @@ module Rodauth
       send_email(create_verify_login_change_email(login))
     end
 
-    def verify_login_change_email_link
-      token_link(verify_login_change_route, verify_login_change_key_param, verify_login_change_key_value)
+    def verify_login_change_email_link(key=verify_login_change_key_value)
+      token_link(verify_login_change_route, verify_login_change_key_param, key)
     end
 
     def get_verify_login_change_login_and_key(id)


### PR DESCRIPTION
This makes it easier to call the `*_email_link` methods outside of a request, which is fairly common because emails are typically delivered in a background job.

## Background

In rodauth-rails, the generated Rodauth configuration currently overrides the email methods to call Action Mailer, which also support delaying the email delivery into a background job. Originally, it was passing the email links directly to mailer arguments (which would end up as background job arguments), but that had issues in API + SPA scenario where the SPA lives on a different subdomain, and I also realized it's probably not secure to include tokens in background job arguments.

```rb
class RodauthMain < Rodauth::Rails::Auth
  configure do
    create_verify_account_email do
      RodauthMailer.verify_account(email_to, verify_account_email_link)
    end
    # ...
  end
end
```
```rb
class RodauthMailer < ApplicationMailer
  def verify_account(recipient, email_link)
    @email_link = email_link

    mail to: recipient
  end
  # ...
end
```

Then I switched to sending only account ID and raw keys, and generated the email link manually:

```rb
class RodauthMain < Rodauth::Rails::Auth
  configure do
    create_verify_account_email do
      RodauthMailer.verify_account(account_id, verify_account_key_value)
    end
    # ...
  end
end
```
```rb
class RodauthMailer < ApplicationMailer
  def verify_account(account_id, key)
    @email_link = rodauth.verify_account_url(key: email_token(account_id, key)) # generate email link
    @account = Account.find(account_id)

    mail to: @account.email, recipient: rodauth.verify_account_email_subject
  end
  # ...
  private

  def email_token(account_id, key)
    "#{account_id}_#{rodauth.compute_hmac(key)}"
  end

  def rodauth
    RodauthApp.rodauth.allocate
  end
end
```

Now I would like to update the generated configuration to automatically work for any configuration, because I expect that authentication emails might largely be shared between different configurations, so it could make sense to use the same mailer. This complicates the logic, so I was exploring whether I could simplify email link generation by reusing Rodauth's methods. If these changes are merged, it would allow me to do the following:

```rb
class RodauthMain < Rodauth::Rails::Auth
  configure do
    create_verify_account_email do
      RodauthMailer.verify_account(self.class.configuration_name, account_id, verify_account_key_value)
    end
    # ...
  end
end
```
```rb
class RodauthMailer < ApplicationMailer
  def verify_account(name, account_id, key)
    @email_link = rodauth(name, account_id).verify_account_email_link(key) # reuse email link
    @account = Account.find(account_id)

    mail to: @account.email, recipient: rodauth(name).verify_account_email_subject
  end
  # ...
  private

  def rodauth(name, account_id = nil)
    instance = RodauthApp.rodauth(name).allocate
    instance.instance_variable_set(:@account, { id: account_id }) if account_id
    instance
  end
end
```
