### PR TITLE
Add rodauth-model to the list of external features

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -92,6 +92,7 @@
 <ul>
   <li><a href="https://github.com/adam12/rodauth-become_account">rodauth-become_account</a>: Easily switch between Rodauth accounts.</li>
   <li><a href="https://github.com/janko/rodauth-i18n">rodauth-i18n</a>: Provides I18n integration and translations.</li>
+  <li><a href="https://github.com/janko/rodauth-model">rodauth-model</a>: Provides password attribute and associations for account model.</li>
   <li><a href="https://gitlab.com/honeyryderchuck/rodauth-oauth">rodauth-oauth</a>: Implements the OAuth 2.0 protocol on top of Rodauth.</li>
   <li><a href="https://github.com/janko/rodauth-pwned">rodauth-pwned</a>: Checks passwords against the Pwned Passwords API.</li>
   <li><a href="https://github.com/janko/rodauth-rails">rodauth-rails</a>: Provides Rails integration for Rodauth.</li>


### PR DESCRIPTION
I recently extracted this functionality from rodauth-rails, since it wasn't Rails-specific, and finally added support for Sequel models yesterday. So, I thought it's worth adding a link on the website.
