### PR TITLE
Ensure routes can be disabled by setting `*_route` to `nil`/`false`

### DIFF
--- a/doc/guides/paths.rdoc
+++ b/doc/guides/paths.rdoc
@@ -37,3 +37,15 @@ setting:
 
     # ...
   end
+
+There are cases where you may want to disable certain routes. For example, you
+may want to enable the create_account feature to allow creating admins, but
+only make it possible programmatically via internal requests. In this case,
+you should set the corresponding <tt>*_route</tt> method to +nil+:
+
+  plugin :rodauth, name: :admin do
+    enable :create_account
+
+    # disable the /create-account route
+    create_account_route nil
+  end

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -402,7 +402,8 @@ module Rodauth
       db.extension :date_arithmetic if use_date_arithmetic?
       route_hash= {}
       self.class.routes.each do |meth|
-        route_hash["/#{send("#{meth.to_s.sub(/\Ahandle_/, '')}_route")}"] = meth
+        route_meth = "#{meth.to_s.sub(/\Ahandle_/, '')}_route"
+        route_hash["/#{send(route_meth)}"] = meth if send(route_meth)
       end
       self.class.route_hash = route_hash.freeze
     end

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -270,6 +270,31 @@ describe 'Rodauth' do
     page.text.must_equal 'http://www.example.com/auth/login?a[]=b&a[]=c'
   end
 
+  it "should support disabling routes" do
+    rodauth do
+      enable :create_account, :internal_request
+      create_account_route nil
+      login_route false
+    end
+    @no_freeze = true
+    roda do |r|
+      r.rodauth
+      r.root { "home" }
+    end
+    @app.not_found { "not found" }
+
+    visit '/create-account'
+    page.html.must_equal "not found"
+
+    visit '/'
+    page.html.must_equal "home"
+
+    @app.rodauth.route_hash.must_equal({})
+
+    @app.rodauth.create_account(login: "user@example.com", password: "secret")
+    @app.rodauth.account_exists?(login: "user@example.com").must_equal true
+  end
+
   it "should support session key prefix" do
     rodauth do
       session_key_prefix "prefix_"


### PR DESCRIPTION
There are use cases where it makes sense to want to disable certain routes (see https://github.com/janko/rodauth-rails/discussions/110). It appears that setting the `*_route` method to `nil` works, while still keeping the internal request functionality intact. If you agree, I thought it would be useful to have it documented in an official guide.
