### PR TITLE
Add configuration for setting argon2 secret

### DIFF
--- a/doc/argon2.rdoc
+++ b/doc/argon2.rdoc
@@ -46,4 +46,5 @@ memory.
 
 == Auth Value Methods
 
+argon2_secret :: A secret key used as input at hashing time, folded into the value of the hash.
 use_argon2? :: Whether to use the argon2 password hash algorithm for new passwords (true by default). The only reason to set this to false is if you have existing passwords using argon2 that you want to support, but want to use bcrypt for new passwords.

--- a/doc/password_pepper.rdoc
+++ b/doc/password_pepper.rdoc
@@ -15,6 +15,14 @@ If your database already contains password hashes that were created without a
 password pepper, these will get automatically updated with a password pepper
 next time the user successfully enters their password.
 
+If you're using bcrypt (default), you should set +password_maximum_bytes+ so
+that password + pepper don't exceed 72 bytes. This is because bcrypt truncates
+passwords longer than 72 bytes, enabling an attacker to crack the pepper if the
+password bytesize is unlimited. If you're using argon2, you should probably set
++argon2_secret+ instead of using this feature.
+
+== Pepper Rotation
+
 You can rotate the password pepper as well, just make sure to add the previous
 pepper to the +previous_password_peppers+ array. Password hashes using the old
 pepper will get automatically updated on the next successful password match.

--- a/lib/rodauth/features/argon2.rb
+++ b/lib/rodauth/features/argon2.rb
@@ -12,6 +12,7 @@ module Rodauth
   Feature.define(:argon2, :Argon2) do
     depends :login_password_requirements_base
 
+    auth_value_method :argon2_secret, nil
     auth_value_method :use_argon2?, true
 
     private
@@ -35,7 +36,10 @@ module Rodauth
 
     def password_hash(password)
       return super unless use_argon2?
-      ::Argon2::Password.new(password_hash_cost).create(password)
+
+      argon2_params = Hash[password_hash_cost]
+      argon2_params[:secret] = argon2_secret
+      ::Argon2::Password.new(argon2_params).create(password)
     end
 
     def password_hash_match?(hash, password)
@@ -48,6 +52,7 @@ module Rodauth
 
       argon2_params = Hash[extract_password_hash_cost(salt)]
       argon2_params[argon2_salt_option] = Base64.decode64(salt.split('$').last)
+      argon2_params[:secret] = argon2_secret
       ::Argon2::Password.new(argon2_params).create(password)
     end
 
@@ -75,7 +80,7 @@ module Rodauth
     end
 
     def argon2_password_hash_match?(hash, password)
-      ::Argon2::Password.verify_password(password, hash)
+      ::Argon2::Password.verify_password(password, hash, argon2_secret)
     end
   end
 end


### PR DESCRIPTION
This allows using argon2's built-in password peppering, and avoid having to use the password_pepper feature.

We also add a security warning for bcrypt, where not having a maximum bytesize limit for passwords enables an attacker to crack the password pepper, due to bcrypt truncating passwords longer than 72 bytes. The attack consists of setting a 71-byte password, then attempting to log in with a password of 72 bytes, changing the last byte until the login succeeds (secret keys are usually alphanumeric strings, so there aren't that many possibilities). In that case, the last byte is the first byte of the pepper. Then rinse-and-repeat until the attacker obtains the whole pepper. I found this out from @rafalrothenberger's [recent talk](https://www.youtube.com/watch?v=ISPYQvnLW9c&t=336s&ab_channel=wrocloverb).
