### PR TITLE
Set configuration name to internal request classes

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -340,6 +340,7 @@ module Rodauth
 
       klass = self.class
       internal_class = Class.new(klass)
+      internal_class.instance_variable_set(:@configuration_name, klass.configuration_name)
 
       if blocks = klass.instance_variable_get(:@internal_request_configuration_blocks)
         configuration = internal_class.configuration

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -210,6 +210,22 @@ describe 'Rodauth' do
     auth_class.configuration_name.must_equal :admin
   end
 
+  it "should set configuration name for internal request classes" do
+    @no_precompile = @no_freeze = true
+    rodauth do
+      enable :internal_request
+    end
+    roda(name: :admin) do |r|
+      r.rodauth
+    end
+    app.plugin(:rodauth, auth_class: Class.new(Rodauth::Auth), name: :secondary) do
+      enable :internal_request
+    end
+
+    app.rodauth(:admin).const_get(:InternalRequest).configuration_name.must_equal :admin
+    app.rodauth(:secondary).const_get(:InternalRequest).configuration_name.must_equal :secondary
+  end
+
   it "should not require passing a block when loading the plugin" do
     app = Class.new(Base)
     app.plugin :rodauth


### PR DESCRIPTION
Since the `@configuration_name` instance variable is the only one not automatically inherited on subclassing, it got lost on the internal request class, which can break user code that rely on it being set. For example, I had code that would save an account type to the database based on the configuration name, but it didn't work correctly when creating the account via an internal request. This PR should fix the issue.
