### PR TITLE
Skip displaying links for disabled routes

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -126,8 +126,8 @@ module Rodauth
       route_meth = :"#{name}_route"
       auth_value_method route_meth, default
 
-      define_method(:"#{name}_path"){|opts={}| route_path(send(route_meth), opts)}
-      define_method(:"#{name}_url"){|opts={}| route_url(send(route_meth), opts)}
+      define_method(:"#{name}_path"){|opts={}| route_path(send(route_meth), opts) if send(route_meth)}
+      define_method(:"#{name}_url"){|opts={}| route_url(send(route_meth), opts) if send(route_meth)}
 
       handle_meth = :"handle_#{name}"
       internal_handle_meth = :"_#{handle_meth}"

--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -78,7 +78,7 @@ module Rodauth
 
     def _two_factor_auth_links
       links = (super if defined?(super)) || []
-      if authenticated_by.length == 1 && !authenticated_by.include?('password') && has_password?
+      if authenticated_by.length == 1 && !authenticated_by.include?('password') && has_password? && confirm_password_route
         links << [5, confirm_password_path, confirm_password_link_text]
       end
       links

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -115,7 +115,9 @@ module Rodauth
     private
 
     def _login_form_footer_links
-      super << [10, create_account_path, create_account_link_text]
+      links = super
+      links << [10, create_account_path, create_account_link_text] if create_account_route
+      links
     end
 
     def _new_account(login)

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -334,19 +334,19 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [20, otp_auth_path, otp_auth_link_text] if otp_available?
+      links << [20, otp_auth_path, otp_auth_link_text] if otp_available? && otp_auth_route
       links
     end
 
     def _two_factor_setup_links
       links = super
-      links << [20, otp_setup_path, otp_setup_link_text] unless otp_exists?
+      links << [20, otp_setup_path, otp_setup_link_text] unless otp_exists? || !otp_setup_route
       links
     end
 
     def _two_factor_remove_links
       links = super
-      links << [20, otp_disable_path, otp_disable_link_text] if otp_exists?
+      links << [20, otp_disable_path, otp_disable_link_text] if otp_exists? && otp_disable_route
       links
     end
 

--- a/lib/rodauth/features/recovery_codes.rb
+++ b/lib/rodauth/features/recovery_codes.rb
@@ -207,13 +207,13 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [40, recovery_auth_path, recovery_auth_link_text] if recovery_codes_available?
+      links << [40, recovery_auth_path, recovery_auth_link_text] if recovery_codes_available? && recovery_auth_route
       links
     end
 
     def _two_factor_setup_links
       links = super
-      links << [40, recovery_codes_path, recovery_codes_link_text] if (recovery_codes_primary? || uses_two_factor_authentication?)
+      links << [40, recovery_codes_path, recovery_codes_link_text] if (recovery_codes_primary? || uses_two_factor_authentication?) && recovery_codes_route
       links
     end
 

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -209,7 +209,9 @@ module Rodauth
     private
 
     def _login_form_footer_links
-      super << [20, reset_password_request_path, reset_password_request_link_text]
+      links = super
+      links << [20, reset_password_request_path, reset_password_request_link_text] if reset_password_request_route
+      links
     end
 
     def reset_password_email_recently_sent?

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -451,19 +451,19 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [30, sms_request_path, sms_auth_link_text] if sms_available?
+      links << [30, sms_request_path, sms_auth_link_text] if sms_available? && sms_request_route
       links
     end
 
     def _two_factor_setup_links
       links = super
-      links << [30, sms_setup_path, sms_setup_link_text] if !sms_setup? && (sms_codes_primary? || uses_two_factor_authentication?)
+      links << [30, sms_setup_path, sms_setup_link_text] if !sms_setup? && (sms_codes_primary? || uses_two_factor_authentication?) && sms_setup_route
       links
     end
 
     def _two_factor_remove_links
       links = super
-      links << [30, sms_disable_path, sms_disable_link_text] if sms_setup?
+      links << [30, sms_disable_path, sms_disable_link_text] if sms_setup? && sms_disable_route
       links
     end
 

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -251,7 +251,7 @@ module Rodauth
 
     def _login_form_footer_links
       links = super
-      if !param_or_nil(login_param) || ((account || account_from_login(param(login_param))) && allow_resending_verify_account_email?)
+      if (!param_or_nil(login_param) || ((account || account_from_login(param(login_param))) && allow_resending_verify_account_email?)) && verify_account_resend_route
         links << [30, verify_account_resend_path, verify_account_resend_link_text]
       end
       links

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -413,17 +413,19 @@ module Rodauth
 
     def _two_factor_auth_links
       links = super
-      links << [10, webauthn_auth_path, webauthn_auth_link_text] if webauthn_setup? && !two_factor_login_type_match?('webauthn')
+      links << [10, webauthn_auth_path, webauthn_auth_link_text] if webauthn_setup? && !two_factor_login_type_match?('webauthn') && webauthn_auth_route
       links
     end
 
     def _two_factor_setup_links
-      super << [10, webauthn_setup_path, webauthn_setup_link_text]
+      links = super
+      links << [10, webauthn_setup_path, webauthn_setup_link_text] if webauthn_setup_route
+      links
     end
 
     def _two_factor_remove_links
       links = super
-      links << [10, webauthn_remove_path, webauthn_remove_link_text] if webauthn_setup?
+      links << [10, webauthn_remove_path, webauthn_remove_link_text] if webauthn_setup? && webauthn_remove_route
       links
     end
 

--- a/spec/create_account_spec.rb
+++ b/spec/create_account_spec.rb
@@ -99,6 +99,25 @@ describe 'Rodauth create_account feature' do
     page.html.must_include("Logged In: foo2@example.com")
   end
 
+  it "should not display create account link on login page if route is disabled" do
+    route = 'create-account'
+    rodauth do
+      enable :create_account, :login
+      create_account_route { route }
+    end
+    roda do |r|
+      r.rodauth
+    end
+
+    visit '/login'
+    click_on 'Create a New Account'
+    page.current_path.must_equal '/create-account'
+
+    route = nil
+    visit '/login'
+    page.html.wont_include "Create a New Account"
+  end
+
   [:jwt, :json].each do |json|
     it "should support creating accounts via #{json}" do
       rodauth do

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -245,6 +245,25 @@ describe 'Rodauth reset_password feature' do
     proc{click_button 'Request Password Reset'}.must_raise StandardError
   end
 
+  it "should not display reset password request link on login page if route is disabled" do
+    route = 'reset-password-request'
+    rodauth do
+      enable :login, :reset_password
+      reset_password_request_route { route }
+    end
+    roda do |r|
+      r.rodauth
+    end
+
+    visit '/login'
+    click_on 'Forgot Password?'
+    page.current_path.must_equal '/reset-password-request'
+
+    route = nil
+    visit '/login'
+    page.html.wont_include "Forgot Password?"
+  end
+
   [:jwt, :json].each do |json|
     it "should support resetting passwords for accounts via #{json}" do
       rodauth do

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -312,7 +312,7 @@ describe 'Rodauth' do
     @no_freeze = true
     roda do |r|
       r.rodauth
-      r.root { "home" }
+      r.root { "create_account_path: #{rodauth.create_account_path.inspect}, create_account_url: #{rodauth.create_account_url.inspect}" }
     end
     @app.not_found { "not found" }
 
@@ -320,7 +320,7 @@ describe 'Rodauth' do
     page.html.must_equal "not found"
 
     visit '/'
-    page.html.must_equal "home"
+    page.html.must_equal "create_account_path: nil, create_account_url: nil"
 
     @app.rodauth.route_hash.must_equal({})
 


### PR DESCRIPTION
I recently added an admin section to the demo Rails app, and I wanted to show the option of enabling the create_account feature, but allowing account creation only through internal requests, by disabling the HTTP route via `create_account_route nil`. This worked, but I noticed that the login page still displayed the registration link, even though the route was disabled. Since there is no information about the route name anyway, I thought it would make sense to skip displaying it.

I then applied this idea to all other places where links are being displayed. I also updated `*_path` and `*_url` methods to return `nil` for disabled routes.
