### PR TITLE
Raise explicit error when `hmac_secret` is not set but is required

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -679,6 +679,8 @@ module Rodauth
     end
 
     def compute_raw_hmac(data)
+      raise ArgumentError, "hmac_secret not set" unless hmac_secret
+
       OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, hmac_secret, data)
     end
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -1199,4 +1199,15 @@ describe 'Rodauth' do
     end.must_equal true
     session['check_type'].must_equal false
   end
+
+  it "should raise argument error when hmac_secret is missing but required" do
+    rodauth do
+    end
+    roda do |r|
+      rodauth.compute_hmac("secret")
+    end
+
+    error = proc{visit "/"}.must_raise(ArgumentError)
+    error.message.must_equal "hmac_secret not set"
+  end
 end


### PR DESCRIPTION
Some features such as webauthn and active sessions require `hmac_secret` to be set, but raise a cryptic error when it's missing:

```
TypeError: no implicit conversion of nil into String
```

Since it's not clear from this error that the issue is in `hmac_secret` not being set, we change this to raise an explicit `ArgumentError` (like the JWT feature does for `jwt_secret`).
