### PR TITLE
Use Ruby 1.9+ Hash syntax in the README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,7 +80,7 @@ features in use. These are development dependencies instead of
 runtime dependencies in the gem as it is possible to run without them:
 
 tilt :: Used by all features unless in JSON API only mode.
-rack_csrf :: Used for CSRF support if the :csrf=>:rack_csrf plugin
+rack_csrf :: Used for CSRF support if the <tt>csrf: :rack_csrf</tt> plugin
              option is given (the default is to use Roda's route_csrf
              plugin, as that allows for more secure request-specific
              tokens).
@@ -336,18 +336,18 @@ When running the migration for the +ph+ user you'll need to modify a couple
 things for the schema changes:
 
   create_table(:account_password_hashes) do
-    foreign_key :id, Sequel[:${DATABASE_NAME}][:accounts], :primary_key=>true, :type=>:Bignum
-    String :password_hash, :null=>false
+    foreign_key :id, Sequel[:${DATABASE_NAME}][:accounts], primary_key: true, type: :Bignum
+    String :password_hash, null: false
   end
-  Rodauth.create_database_authentication_functions(self, :table_name=>Sequel[:${DATABASE_NAME}_password][:account_password_hashes])
+  Rodauth.create_database_authentication_functions(self, table_name: Sequel[:${DATABASE_NAME}_password][:account_password_hashes])
 
   # if using the disallow_password_reuse feature:
   create_table(:account_previous_password_hashes) do
-    primary_key :id, :type=>:Bignum
-    foreign_key :account_id, Sequel[:${DATABASE_NAME}][:accounts], :type=>:Bignum
-    String :password_hash, :null=>false
+    primary_key :id, type: :Bignum
+    foreign_key :account_id, Sequel[:${DATABASE_NAME}][:accounts], type: :Bignum
+    String :password_hash, null: false
   end
-  Rodauth.create_database_previous_password_check_functions(self, :table_name=>Sequel[:${DATABASE_NAME}_password][:account_previous_password_hashes])
+  Rodauth.create_database_previous_password_check_functions(self, table_name: Sequel[:${DATABASE_NAME}_password][:account_previous_password_hashes])
 
 You'll also need to use the following Rodauth configuration methods so that the
 app account calls functions in a separate schema:
@@ -412,33 +412,33 @@ Note that these migrations require Sequel 4.35.0+.
 
       # Used by the account verification and close account features
       create_table(:account_statuses) do
-        Integer :id, :primary_key=>true
-        String :name, :null=>false, :unique=>true
+        Integer :id, primary_key: true
+        String :name, null: false, unique: true
       end
       from(:account_statuses).import([:id, :name], [[1, 'Unverified'], [2, 'Verified'], [3, 'Closed']])
 
       db = self
       create_table(:accounts) do
-        primary_key :id, :type=>:Bignum
-        foreign_key :status_id, :account_statuses, :null=>false, :default=>1
+        primary_key :id, type: :Bignum
+        foreign_key :status_id, :account_statuses, null: false, default: 1
         if db.database_type == :postgres
-          citext :email, :null=>false
-          constraint :valid_email, :email=>/^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$/
+          citext :email, null: false
+          constraint :valid_email, email: /^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$/
         else
-          String :email, :null=>false
+          String :email, null: false
         end
         if db.supports_partial_indexes?
-          index :email, :unique=>true, :where=>{:status_id=>[1, 2]}
+          index :email, unique: true, where: {status_id: [1, 2]}
         else
-          index :email, :unique=>true
+          index :email, unique: true
         end
       end
 
       deadline_opts = proc do |days|
         if database_type == :mysql
-          {:null=>false}
+          {null: false}
         else
-          {:null=>false, :default=>Sequel.date_add(Sequel::CURRENT_TIMESTAMP, :days=>days)}
+          {null: false, default: Sequel.date_add(Sequel::CURRENT_TIMESTAMP, days: days)}
         end
       end
 
@@ -452,140 +452,140 @@ Note that these migrations require Sequel 4.35.0+.
         String
       end
       create_table(:account_authentication_audit_logs) do
-        primary_key :id, :type=>:Bignum
-        foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
-        DateTime :at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
-        String :message, :null=>false
+        primary_key :id, type: :Bignum
+        foreign_key :account_id, :accounts, null: false, type: :Bignum
+        DateTime :at, null: false, default: Sequel::CURRENT_TIMESTAMP
+        String :message, null: false
         column :metadata, json_type
-        index [:account_id, :at], :name=>:audit_account_at_idx
-        index :at, :name=>:audit_at_idx
+        index [:account_id, :at], name: :audit_account_at_idx
+        index :at, name: :audit_at_idx
       end
 
       # Used by the password reset feature
       create_table(:account_password_reset_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
         DateTime :deadline, deadline_opts[1]
-        DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       # Used by the jwt refresh feature
       create_table(:account_jwt_refresh_keys) do
-        primary_key :id, :type=>:Bignum
-        foreign_key :account_id, :accounts, :null=>false, :type=>:Bignum
-        String :key, :null=>false
+        primary_key :id, type: :Bignum
+        foreign_key :account_id, :accounts, null: false, type: :Bignum
+        String :key, null: false
         DateTime :deadline, deadline_opts[1]
-        index :account_id, :name=>:account_jwt_rk_account_id_idx
+        index :account_id, name: :account_jwt_rk_account_id_idx
       end
 
       # Used by the account verification feature
       create_table(:account_verification_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
-        DateTime :requested_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
-        DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
+        DateTime :requested_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+        DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       # Used by the verify login change feature
       create_table(:account_login_change_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
-        String :login, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
+        String :login, null: false
         DateTime :deadline, deadline_opts[1]
       end
 
       # Used by the remember me feature
       create_table(:account_remember_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
         DateTime :deadline, deadline_opts[14]
       end
 
       # Used by the lockout feature
       create_table(:account_login_failures) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        Integer :number, :null=>false, :default=>1
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        Integer :number, null: false, default: 1
       end
       create_table(:account_lockouts) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
         DateTime :deadline, deadline_opts[1]
         DateTime :email_last_sent
       end
 
       # Used by the email auth feature
       create_table(:account_email_auth_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
         DateTime :deadline, deadline_opts[1]
-        DateTime :email_last_sent, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       # Used by the password expiration feature
       create_table(:account_password_change_times) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        DateTime :changed_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        DateTime :changed_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       # Used by the account expiration feature
       create_table(:account_activity_times) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        DateTime :last_activity_at, :null=>false
-        DateTime :last_login_at, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        DateTime :last_activity_at, null: false
+        DateTime :last_login_at, null: false
         DateTime :expired_at
       end
 
       # Used by the single session feature
       create_table(:account_session_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
       end
 
       # Used by the active sessions feature
       create_table(:account_active_session_keys) do
-        foreign_key :account_id, :accounts, :type=>:Bignum
+        foreign_key :account_id, :accounts, type: :Bignum
         String :session_id
-        Time :created_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
-        Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        Time :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+        Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
         primary_key [:account_id, :session_id]
       end
 
       # Used by the webauthn feature
       create_table(:account_webauthn_user_ids) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :webauthn_id, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :webauthn_id, null: false
       end
       create_table(:account_webauthn_keys) do
-        foreign_key :account_id, :accounts, :type=>:Bignum
+        foreign_key :account_id, :accounts, type: :Bignum
         String :webauthn_id
-        String :public_key, :null=>false
-        Integer :sign_count, :null=>false
-        Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        String :public_key, null: false
+        Integer :sign_count, null: false
+        Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
         primary_key [:account_id, :webauthn_id]
       end
 
       # Used by the otp feature
       create_table(:account_otp_keys) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :key, :null=>false
-        Integer :num_failures, :null=>false, :default=>0
-        Time :last_use, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :key, null: false
+        Integer :num_failures, null: false, default: 0
+        Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       # Used by the recovery codes feature
       create_table(:account_recovery_codes) do
-        foreign_key :id, :accounts, :type=>:Bignum
+        foreign_key :id, :accounts, type: :Bignum
         String :code
         primary_key [:id, :code]
       end
 
       # Used by the sms codes feature
       create_table(:account_sms_codes) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :phone_number, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :phone_number, null: false
         Integer :num_failures
         String :code
-        DateTime :code_issued_at, :null=>false, :default=>Sequel::CURRENT_TIMESTAMP
+        DateTime :code_issued_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       end
 
       case database_type
@@ -652,8 +652,8 @@ Second migration, run using the +ph+ account:
   Sequel.migration do
     up do
       create_table(:account_password_hashes) do
-        foreign_key :id, :accounts, :primary_key=>true, :type=>:Bignum
-        String :password_hash, :null=>false
+        foreign_key :id, :accounts, primary_key: true, type: :Bignum
+        String :password_hash, null: false
       end
       Rodauth.create_database_authentication_functions(self)
       case database_type
@@ -682,9 +682,9 @@ Second migration, run using the +ph+ account:
 
       # Used by the disallow_password_reuse feature
       create_table(:account_previous_password_hashes) do
-        primary_key :id, :type=>:Bignum
-        foreign_key :account_id, :accounts, :type=>:Bignum
-        String :password_hash, :null=>false
+        primary_key :id, type: :Bignum
+        foreign_key :account_id, :accounts, type: :Bignum
+        String :password_hash, null: false
       end
       Rodauth.create_database_previous_password_check_functions(self)
 
@@ -725,8 +725,8 @@ To support multiple separate migration users, you can run the migration
 for the password user using Sequel's migration API: 
 
   Sequel.extension :migration
-  Sequel.postgres('DATABASE_NAME', :user=>'PASSWORD_USER_NAME') do |db|
-    Sequel::Migrator.run(db, 'path/to/password_user/migrations', :table=>'schema_info_password')
+  Sequel.postgres('DATABASE_NAME', user: 'PASSWORD_USER_NAME') do |db|
+    Sequel::Migrator.run(db, 'path/to/password_user/migrations', table: 'schema_info_password')
   end
 
 If the database is not PostgreSQL, MySQL, or Microsoft SQL Server, or you
@@ -1112,7 +1112,7 @@ providing a name for any alternate configuration:
 
   plugin :rodauth do
   end
-  plugin :rodauth, :name=>:secondary do
+  plugin :rodauth, name: :secondary do
   end
 
 Then in your routing code, any time you call rodauth, you can provide
@@ -1133,7 +1133,7 @@ alternate configurations.  If you are using the remember feature in both
 configurations, you may also want to set a different remember key in the
 alternate configuration:
 
-  plugin :rodauth, :name=>:secondary do
+  plugin :rodauth, name: :secondary do
     session_key_prefix "secondary_"
     remember_cookie_key "_secondary_remember"
   end
@@ -1235,7 +1235,7 @@ Facebook OAuth access token.
 
     account_from_login do |access_token|
       fb = Koala::Facebook::API.new(access_token)
-      if me = fb.get_object('me', :fields=>[:email])
+      if me = fb.get_object('me', fields: [:email])
         me['email']
       end
     end
@@ -1369,7 +1369,7 @@ To add support for handling JSON responses, you can pass the +:json+
 option to the plugin, and enable the JWT feature in addition to
 other features you plan to use:
 
-  plugin :rodauth, :json=>true do
+  plugin :rodauth, json: true do
     enable :login, :logout, :jwt
   end
 
@@ -1377,12 +1377,12 @@ If you do not want to load the HTML plugins that Rodauth usually loads
 (render, csrf, flash, h), because you are building a JSON-only API,
 pass <tt>:json => :only</tt>
 
-  plugin :rodauth, :json=>:only do
+  plugin :rodauth, json: :only do
     enable :login, :logout, :jwt
   end
 
 Note that by default, the features that send email depend on the
-render plugin, so if using the <tt>:json=>:only</tt> option, you
+render plugin, so if using the <tt>json: :only</tt> option, you
 either need to load the render plugin manually or you need to
 use the necessary *_email_body configuration options to specify
 the body of the emails.
@@ -1391,7 +1391,7 @@ The JWT feature enables JSON API support for all of the other features
 that Rodauth ships with. If you would like JSON API access that still uses
 rack session for storing session data, enable the JSON feature instead:
 
-  plugin :rodauth, :json=>true do
+  plugin :rodauth, json: true do
     enable :login, :logout, :json
     only_json? true # if you want to only handle JSON requests
   end


### PR DESCRIPTION
This converts hashrockets in the documentation to the Ruby 1.9+ syntax, as discussed in https://github.com/jeremyevans/rodauth/discussions/27 (only README had it).
