### PR TITLE
Fix black QR code in TOTP feature

### DIFF
--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -308,7 +308,7 @@ module Rodauth
     end
 
     def otp_qr_code
-      svg = RQRCode::QRCode.new(otp_provisioning_uri).as_svg(:module_size=>8, :viewbox=>true, :use_path=>true, :fill=>"#fff")
+      svg = RQRCode::QRCode.new(otp_provisioning_uri).as_svg(:module_size=>8, :viewbox=>true, :use_path=>true, :fill=>"fff")
       svg.sub(/\A<\?xml version="1\.0" standalone="yes"\?>/, '')
     end
 


### PR DESCRIPTION
The `#` is already prepended to the passed fill color, so we need to pass it without a `#`, otherwise we get a `##fff` fill, which results in a completely black square.

Fixes https://github.com/janko/rodauth-rails/issues/169
