### PR TITLE
Make `email_from`, `email_to`, and `token_param_value` methods public

### DIFF
--- a/lib/rodauth/features/email_base.rb
+++ b/lib/rodauth/features/email_base.rb
@@ -23,6 +23,14 @@ module Rodauth
       require 'mail' if require_mail?
     end
 
+    def email_from
+      "webmaster@#{domain}"
+    end
+
+    def email_to
+      account[login_column]
+    end
+
     private
 
     def send_email(email)
@@ -40,14 +48,6 @@ module Rodauth
       m.subject = "#{email_subject_prefix}#{subject}"
       m.body = body
       m
-    end
-
-    def email_from
-      "webmaster@#{domain}"
-    end
-
-    def email_to
-      account[login_column]
     end
 
     def token_link(route, param, key)


### PR DESCRIPTION
The `email_from` and `email_to` methods make it easier to create custom emails in a background job, where the Rodauth instance needs to be re-created.

The `token_param_value` method makes it easier to generate an email token directly, to be used for a custom email link to a frontend app, for sending it in an HTTP request to a different service, or anything else.

Below is an example Rails setup where these would be useful:

```rb
class RodauthMain < Rodauth::Rails::Auth
  configure do
    send_verify_account_email do
      RodauthMailer.verify_account(account_id, verify_account_key_value).deliver_later
    end
  end
end
```
```rb
class RodauthMailer < ActionMailer::Base
  def verify_account(account_id, key)
    @rodauth = rodauth(account_id)
    @email_link = "https://frontend.example.com/account/verify?token=#{@rodauth.token_param_value(key)}"

    mail from: @rodauth.email_from, to: @rodauth.email_to, subject: @rodauth.verify_account_email_subject
  end

  private

  def rodauth(account_id)
    instance = RodauthApp.rodauth.allocate
    instance.instance_eval { @account = account_ds(account_id).first }
    instance
  end
end
```
