### PR TITLE
Raise error when Sequel database is missing

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -264,7 +264,7 @@ module Rodauth
     end
 
     def db
-      Sequel::DATABASES.first
+      Sequel::DATABASES.first or raise ArgumentError, "Sequel database connection is missing"
     end
 
     def password_field_autocomplete_value

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -1230,4 +1230,14 @@ describe 'Rodauth' do
     error = proc{visit "/"}.must_raise(ArgumentError)
     error.message.must_equal "hmac_secret not set"
   end
+
+  it "should raise error when sequel database is missing" do
+    database = Sequel::DATABASES.pop
+
+    rodauth {}
+    error = proc { roda {} }.must_raise(ArgumentError)
+    error.message.must_equal "Sequel database connection is missing"
+
+    Sequel::DATABASES.push database
+  end
 end


### PR DESCRIPTION
Currently, when a person requires Sequel but doesn't connect to the database, they get a `NoMethodError` because `database_type` is getting called on `nil` in `#post_configure` method. I thought it would be good to have a more explicit error message for people newer to Sequel.
