### PR TITLE
add translatable method to customize account creation label

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -46,6 +46,7 @@ module Rodauth
     translatable_method :no_matching_login_message, "no matching login"
     auth_value_method :login_param, 'login'
     translatable_method :login_label, 'Login'
+    translatable_method :create_account_label, 'Register'
     translatable_method :password_label, 'Password'
     auth_value_method :password_param, 'password'
     session_key :session_key, :account_id


### PR DESCRIPTION
Hey,
i'm not sure if i'm doing this right. it seems this is a trivial duplication of the existing login label functionality, and i could not find any related tests.

use case is simple, i would like to customize the Label for the sign up form, but as far as i can tell, it currently uses the login_label method, so there is currently no way to differentiate.

i am using rodauth through the rails-rodauth wrapper by @janko but i think that one just forwards that method call to rodauth, right?

if my presumptions are right, this pr might be considerable.

thank you.