### PR TITLE
Hide text field in WebAuthn setup & auth forms

### DIFF
--- a/templates/webauthn-auth.str
+++ b/templates/webauthn-auth.str
@@ -3,7 +3,7 @@
   #{rodauth.csrf_tag(rodauth.webauthn_auth_form_path)}
   <input type="hidden" name="#{rodauth.webauthn_auth_challenge_param}" value="#{cred.challenge}" />
   <input type="hidden" name="#{rodauth.webauthn_auth_challenge_hmac_param}" value="#{rodauth.compute_hmac(cred.challenge)}" />
-  <input class="rodauth_hidden" aria-hidden="true" type="text" name="#{rodauth.webauthn_auth_param}" id="webauthn-auth" value="" />
+  <input class="rodauth_hidden d-none" aria-hidden="true" type="text" name="#{rodauth.webauthn_auth_param}" id="webauthn-auth" value="" />
   <div id="webauthn-auth-button"> 
     #{rodauth.button(rodauth.webauthn_auth_button)}
   </div>

--- a/templates/webauthn-setup.str
+++ b/templates/webauthn-setup.str
@@ -3,7 +3,7 @@
   #{rodauth.csrf_tag}
   <input type="hidden" name="#{rodauth.webauthn_setup_challenge_param}" value="#{cred.challenge}" />
   <input type="hidden" name="#{rodauth.webauthn_setup_challenge_hmac_param}" value="#{rodauth.compute_hmac(cred.challenge)}" />
-  <input class="rodauth_hidden" aria-hidden="true" type="text" name="#{rodauth.webauthn_setup_param}" id="webauthn-setup" value="" />
+  <input class="rodauth_hidden d-none" aria-hidden="true" type="text" name="#{rodauth.webauthn_setup_param}" id="webauthn-setup" value="" />
   #{rodauth.render('password-field') if rodauth.two_factor_modifications_require_password?}
   <div id="webauthn-setup-button"> 
     #{rodauth.button(rodauth.webauthn_setup_button)}


### PR DESCRIPTION
As discussed in https://github.com/jeremyevans/rodauth/discussions/293, this hides the text field that is autofilled by JavaScript on WebAuthn setup & auth forms when using Bootstrap.
