### PR TITLE
Rename `webauth_credentials_for_get` to `webauthn_credentials_for_get`

### DIFF
--- a/doc/webauthn.rdoc
+++ b/doc/webauthn.rdoc
@@ -104,7 +104,7 @@ remove_all_webauthn_keys_and_user_ids :: Remove all WebAuthn credentials and the
 remove_webauthn_key(webauthn_id) :: Remove the WebAuthn credential with the given WebAuthn ID from the current account.
 valid_new_webauthn_credential?(webauthn_credential) :: Check wheck the WebAuthn credential provided by the client during registration is valid.
 valid_webauthn_credential_auth?(webauthn_credential) :: Check wheck the WebAuthn credential provided by the client during authentication is valid.
-webauth_credential_options_for_get :: WebAuthn credential options to provide to the client during WebAuthn authentication.
+webauthn_credential_options_for_get :: WebAuthn credential options to provide to the client during WebAuthn authentication.
 webauthn_auth_js_path :: The path to the WebAuthn authentication javascript.
 webauthn_auth_view :: The HTML to use for the page for authenticating via WebAuthn.
 webauthn_remove_authenticated_session :: Remove the authenticated WebAuthn ID, used when removing the WebAuthn credential with the ID after authenticating with it.

--- a/lib/rodauth/features/json.rb
+++ b/lib/rodauth/features/json.rb
@@ -107,7 +107,7 @@ module Rodauth
     def before_webauthn_auth_route
       super if defined?(super)
       if use_json? && !param_or_nil(webauthn_auth_param)
-        cred = webauth_credential_options_for_get
+        cred = webauthn_credential_options_for_get
         json_response[webauthn_auth_param] = cred.as_json
         json_response[webauthn_auth_challenge_param] = cred.challenge
         json_response[webauthn_auth_challenge_hmac_param] = compute_hmac(cred.challenge)
@@ -117,7 +117,7 @@ module Rodauth
     def before_webauthn_login_route
       super if defined?(super)
       if use_json? && !param_or_nil(webauthn_auth_param) && account_from_login(param(login_param))
-        cred = webauth_credential_options_for_get
+        cred = webauthn_credential_options_for_get
         json_response[webauthn_auth_param] = cred.as_json
         json_response[webauthn_auth_challenge_param] = cred.challenge
         json_response[webauthn_auth_challenge_hmac_param] = compute_hmac(cred.challenge)

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -102,12 +102,14 @@ module Rodauth
       :valid_new_webauthn_credential?,
       :valid_webauthn_credential_auth?,
       :webauthn_auth_js_path,
-      :webauth_credential_options_for_get,
+      :webauthn_credential_options_for_get,
       :webauthn_remove_authenticated_session,
       :webauthn_setup_js_path,
       :webauthn_update_session,
       :webauthn_user_name,
     )
+
+    def_deprecated_alias :webauthn_credential_options_for_get, :webauth_credential_options_for_get
 
     route(:webauthn_auth_js) do |r|
       before_webauthn_auth_js_route
@@ -315,7 +317,7 @@ module Rodauth
         webauthn_credential.verify(challenge)
     end
 
-    def webauth_credential_options_for_get
+    def webauthn_credential_options_for_get
       WebAuthn::Credential.options_for_get(
         :allow => account_webauthn_ids,
         :timeout => webauthn_auth_timeout,

--- a/templates/webauthn-auth.str
+++ b/templates/webauthn-auth.str
@@ -1,4 +1,4 @@
-<form method="post" action="#{rodauth.webauthn_auth_form_path}" class="rodauth" role="form" id="webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauth_credential_options_for_get).as_json.to_json)}">
+<form method="post" action="#{rodauth.webauthn_auth_form_path}" class="rodauth" role="form" id="webauthn-auth-form" data-credential-options="#{h((cred = rodauth.webauthn_credential_options_for_get).as_json.to_json)}">
   #{rodauth.webauthn_auth_additional_form_tags}
   #{rodauth.csrf_tag(rodauth.webauthn_auth_form_path)}
   <input type="hidden" name="#{rodauth.webauthn_auth_challenge_param}" value="#{cred.challenge}" />


### PR DESCRIPTION
As discussed in https://github.com/jeremyevans/rodauth/discussions/293, this renames `webauth_credentials_for_get` to `webauthn_credentials_for_get` for consistency, and leaves the deprecated alias.
