### PR TITLE
Support configuring symbol param keys for convenience

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -480,7 +480,7 @@ module Rodauth
     end
 
     def raw_param(key)
-      request.params[key]
+      request.params[key.to_s]
     end
 
     def base_url

--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -47,7 +47,7 @@ module Rodauth
     end
 
     def raw_param(k)
-      @params[k]
+      @params[k.to_s]
     end
 
     def set_error_flash(message)

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -61,6 +61,25 @@ describe 'Rodauth' do
     page.body.must_include 'Logged In'
   end
 
+  it "should support setting symbol param keys" do
+    rodauth do
+      enable :login, :internal_request
+      login_param :email
+    end
+    roda do |r|
+      r.rodauth
+      r.root{view :content=>""}
+    end
+
+    visit "/login"
+    fill_in "Login", with: "foo@example.com"
+    fill_in "Password", with: "0123456789"
+    click_on "Login"
+    page.find("#notice_flash").text.must_equal "You have been logged in"
+
+    app.rodauth.login(login: "foo@example.com", password: "0123456789")
+  end
+
   it "should support template_opts" do
     rodauth do
       enable :login


### PR DESCRIPTION
People how are used to accessing request parameters via symbol keys (Rails, Sinatra) will probably try configuring `*_param` values with symbol keys, and be surprised the param is not being found (see https://github.com/janko/rodauth-rails/discussions/191). We can have their back by automatically converting set param keys into strings.

I was considering doing this change only in rodauth-rails, but I didn't see how I can handle the internal_request part, given that the `rails` feature has to be loaded before any user configuration. I thought this change would be useful for folks coming from other frameworks as well, such as Sinatra, where it's idiomatic to access params via symbol keys.
