### PR TITLE
Extract `webauthn_key_insert_hash` auth method

### DIFF
--- a/doc/webauthn.rdoc
+++ b/doc/webauthn.rdoc
@@ -104,9 +104,10 @@ remove_all_webauthn_keys_and_user_ids :: Remove all WebAuthn credentials and the
 remove_webauthn_key(webauthn_id) :: Remove the WebAuthn credential with the given WebAuthn ID from the current account.
 valid_new_webauthn_credential?(webauthn_credential) :: Check wheck the WebAuthn credential provided by the client during registration is valid.
 valid_webauthn_credential_auth?(webauthn_credential) :: Check wheck the WebAuthn credential provided by the client during authentication is valid.
-webauthn_credential_options_for_get :: WebAuthn credential options to provide to the client during WebAuthn authentication.
 webauthn_auth_js_path :: The path to the WebAuthn authentication javascript.
 webauthn_auth_view :: The HTML to use for the page for authenticating via WebAuthn.
+webauthn_credential_options_for_get :: WebAuthn credential options to provide to the client during WebAuthn authentication.
+webauthn_key_insert_hash(webauthn_credential) :: The hash to insert into the +webauthn_keys_table+.
 webauthn_remove_authenticated_session :: Remove the authenticated WebAuthn ID, used when removing the WebAuthn credential with the ID after authenticating with it.
 webauthn_remove_view :: The HTML to use for the page for removing an existing WebAuthn authenticator.
 webauthn_setup_js_path :: The path to the WebAuthn registration javascript.

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -103,6 +103,7 @@ module Rodauth
       :valid_webauthn_credential_auth?,
       :webauthn_auth_js_path,
       :webauthn_credential_options_for_get,
+      :webauthn_key_insert_hash,
       :webauthn_remove_authenticated_session,
       :webauthn_setup_js_path,
       :webauthn_update_session,
@@ -348,12 +349,7 @@ module Rodauth
     end
 
     def add_webauthn_credential(webauthn_credential)
-      webauthn_keys_ds.insert(
-        webauthn_keys_account_id_column => webauthn_account_id,
-        webauthn_keys_webauthn_id_column => webauthn_credential.id,
-        webauthn_keys_public_key_column => webauthn_credential.public_key,
-        webauthn_keys_sign_count_column => Integer(webauthn_credential.sign_count)
-      )
+      webauthn_keys_ds.insert(webauthn_key_insert_hash(webauthn_credential))
       super if defined?(super)
       nil
     end
@@ -433,6 +429,15 @@ module Rodauth
       two_factor_remove_session('webauthn')
       remove_session_value(authenticated_webauthn_id_session_key)
       super
+    end
+
+    def webauthn_key_insert_hash(webauthn_credential)
+      {
+        webauthn_keys_account_id_column => webauthn_account_id,
+        webauthn_keys_webauthn_id_column => webauthn_credential.id,
+        webauthn_keys_public_key_column => webauthn_credential.public_key,
+        webauthn_keys_sign_count_column => Integer(webauthn_credential.sign_count)
+      }
     end
 
     def webauthn_account_id


### PR DESCRIPTION
I was live-streaming integrating WebAuthn with Rodauth, where users can additionally set custom names for authenticator, inspired by apps such as RubyGems.org.

I couldn't add the name column value to the insert hash without copying the code, and given that the webauthn credential from form submission isn't accessible in hooks, I also didn't find an easy way to find the inserted record so that I can update it. So, I thought it would be convenient to have an auth method that can be overridden to add additional columns to webauthn keys.

I considered storing the webauthn credential in an instance variable, to avoid having to pass arguments to `webauthn_key_insert_hash`, but saw that it required multiple changes and possibly wasn't desirable, so I chose the more conservative approach with less changes. This is also more consisent with existing methods that accept the webauthn credential argument.
