### PR TITLE
Make `password_hash` method public

### DIFF
--- a/lib/rodauth/features/argon2.rb
+++ b/lib/rodauth/features/argon2.rb
@@ -15,6 +15,18 @@ module Rodauth
     auth_value_method :argon2_secret, nil
     auth_value_method :use_argon2?, true
 
+    def password_hash(password)
+      return super unless use_argon2?
+
+      if secret = argon2_secret
+        argon2_params = Hash[password_hash_cost]
+        argon2_params[:secret] = secret
+      else
+        argon2_params = password_hash_cost
+      end
+      ::Argon2::Password.new(argon2_params).create(password)
+    end
+
     private
 
     if Argon2::VERSION != '2.1.0'
@@ -32,18 +44,6 @@ module Rodauth
     def password_hash_cost
       return super unless use_argon2?
       argon2_hash_cost 
-    end
-
-    def password_hash(password)
-      return super unless use_argon2?
-
-      if secret = argon2_secret
-        argon2_params = Hash[password_hash_cost]
-        argon2_params[:secret] = secret
-      else
-        argon2_params = password_hash_cost
-      end
-      ::Argon2::Password.new(argon2_params).create(password)
     end
 
     def password_hash_match?(hash, password)

--- a/lib/rodauth/features/login_password_requirements_base.rb
+++ b/lib/rodauth/features/login_password_requirements_base.rb
@@ -75,6 +75,10 @@ module Rodauth
       hash
     end
 
+    def password_hash(password)
+      BCrypt::Password.create(password, :cost=>password_hash_cost)
+    end
+
     private
     
     attr_reader :login_requirement_message
@@ -183,10 +187,6 @@ module Rodauth
 
     def extract_password_hash_cost(hash)
       hash[4, 2].to_i
-    end
-    
-    def password_hash(password)
-      BCrypt::Password.create(password, :cost=>password_hash_cost)
     end
   end
 end

--- a/lib/rodauth/features/password_pepper.rb
+++ b/lib/rodauth/features/password_pepper.rb
@@ -16,11 +16,11 @@ module Rodauth
       result
     end
 
-    private
-
     def password_hash(password)
       super(password + password_pepper.to_s)
     end
+
+    private
 
     def password_hash_match?(hash, password)
       return super if password_pepper.nil?


### PR DESCRIPTION
There are use cases where one might want to create a password hash outside of the request. The rodauth-model gem currently [calls](https://github.com/janko/rodauth-model/blob/9b654f50c284204eda4e92b322b0142a919e91dc/lib/rodauth/model/sequel.rb#L26) this method in the `#password=` setter. The rodauth-rails gem is also now [calling](https://github.com/janko/rodauth-rails/blob/0aeb841b2e9a5950182901c9b3ac2fc8f87bd787/lib/generators/rodauth/templates/test/fixtures/accounts.yml#L4) this method in Active Record fixtures, to more easily support both bcrypt and argon2 along with a potential password pepper.
