### PR TITLE
Consider session not logged in if unverified grace period expired

### DIFF
--- a/lib/rodauth/features/verify_account_grace_period.rb
+++ b/lib/rodauth/features/verify_account_grace_period.rb
@@ -30,6 +30,10 @@ module Rodauth
       false
     end
 
+    def logged_in?
+      super && !unverified_grace_period_expired?
+    end
+
     def require_login
       if unverified_grace_period_expired?
         clear_session


### PR DESCRIPTION
Checking whether the unverified grace period expired in `require_login` created a discrepancy with the `logged_in?` method, where `require_login` could now return a login required response while `logged_in?` still returns true. I introduced this back in https://github.com/jeremyevans/rodauth/pull/211.

This can be problematic in scenarios where the application does some logic based on `logged_in?` before calling `require_login`. Checking unverified grace period expiration would also be skipped in potential applications that check only `logged_in?` without calling `require_login`. Here is an example similar to what we had in a Rails app:

```rb
class App < Roda
  plugin :rodauth do
    # ...
  end

  route do |r|
    # Would call `nil.owned_club` when unverified grace period has expired,
    # because `rodauth.account_from_session` wouldn't find the account.
    @current_club = current_account.owned_club if rodauth.authenticated?

    r.on "api" do
      rodauth.require_authentication
      # ...
    end
  end

  private

  def current_account
    account = rodauth.account || rodauth.account_from_session if rodauth.logged_in?
    @current_account ||= Account.load(account) if account
  end
end
```

We fix this by checking whether unverified grace period expired in `logged_in?`, which will then be applied to `require_login` as well. We also remove clearing of session in this case, because having the expired account ID in the session shouldn't be problematic now that `logged_in?` will return false.
