### PR TITLE
Add password maximum length and requirements examples

### DIFF
--- a/doc/guides/password_requirements.rdoc
+++ b/doc/guides/password_requirements.rdoc
@@ -1,13 +1,16 @@
 = Customize password requirements
 
 By default, Rodauth requires passwords to have at least 6 characters. You can
-modify the minimum length:
+modify the minimum and maximum length:
 
   plugin :rodauth do
     enable :login, :logout, :create_account
 
     # Require passwords to have at least 8 characters
     password_minimum_length 8
+
+    # Don't allow passwords to be too long, to prevent long password DoS attacks
+    password_maximum_length 64
   end
 
 You can use the {disallow common passwords feature}[rdoc-ref:doc/disallow_common_passwords.rdoc]
@@ -25,6 +28,16 @@ can use the <tt>password_meets_requirements?</tt> configuration method.
     enable :login, :logout, :create_account
 
     password_meets_requirements? do |password|
-      #true if password meets requirements, false otherwise
+      super(password) && password_complex_enough?(password)
+    end
+
+    auth_class_eval do
+      # If password doesn't pass custom validation, add field error with error
+      # reason, and return false.
+      def password_complex_enough?(password)
+        return true if password.match?(/\d/) && password.match?(/[^a-zA-Z\d]/)
+        set_password_requirement_error_message(:password_simple, "requires one number and one special character")
+        false
+      end
     end
   end


### PR DESCRIPTION
I saw in the [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls) that setting a maximum password length is recommended to prevent long password Denial of Service attacks, so I thought it's useful to show an example in the guide.

I also recently implemented a custom password complexity validation, and since it required reading the source code, I thought it would be useful to have a concrete example in the docs that people can adapt.
