### PR TITLE
Skip rendering reset password request from on invalid login attempt for internal requests

### DIFF
--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -219,7 +219,7 @@ module Rodauth
     attr_reader :reset_password_key_value
 
     def after_login_failure
-      unless only_json?
+      unless only_json? || internal_request?
         @login_form_header = login_failed_reset_password_request_form
       end
       super

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -318,11 +318,16 @@ describe 'Rodauth reset_password feature' do
       enable :login, :logout, :reset_password, :internal_request
       reset_password_email_last_sent_column nil
       domain 'example.com'
+      csrf_tag { |path=request.path| internal_request? ? fail("must not rely on Roda session") : super(path) }
     end
     roda do |r|
       r.rodauth
       r.root{view :content=>(rodauth.logged_in? ? "Logged In" : "Not Logged")}
     end
+
+    proc do
+      app.rodauth.login(:login=>'foo@example.com', :password=>'invalid')
+    end.must_raise Rodauth::InternalRequestError
 
     proc do
       app.rodauth.reset_password_request(:login=>'foo3@example.com')


### PR DESCRIPTION
The internal request auth subclass doesn't have real request context, and doesn't execute Roda's route block, so it might not have what is necessary to render view templates.

I encountered this when using Rodauth as a library, where the reset password request form failed to render due to missing session handler, raised when Rodauth attempted to generate the CSRF tag.
