### PR TITLE
Add more specs for early rendering on internal requests

### DIFF
--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -318,7 +318,9 @@ describe 'Rodauth reset_password feature' do
       enable :login, :logout, :reset_password, :internal_request
       reset_password_email_last_sent_column nil
       domain 'example.com'
-      csrf_tag { |path=request.path| internal_request? ? fail("must not rely on Roda session") : super(path) }
+      internal_request_configuration do
+        csrf_tag { |*| fail "must not rely on Roda session" }
+      end
     end
     roda do |r|
       r.rodauth


### PR DESCRIPTION
After https://github.com/jeremyevans/rodauth/pull/303, I found more places that are early rendering, which weren't being covered by existing internal request specs (`#before_login_attempt` & `#new_account` in verify_account, `#show_lockout_page` in lockout). Everything seems to be working fine, due to `#set_error_flash` being called before view rendering, but hopefully it's fine to add specs to ensure it continues working 🙂 
