### PR TITLE
Add `#account!` method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1000,6 +1000,8 @@ logged_in? :: Whether the session has been logged in.
 authenticated? :: Similar to +logged_in?+, but if the account has setup two
                   factor authentication, whether the session has authenticated
                   via two factors.
+account! :: Returns the current account record if it has already been loaded,
+            otherwise retrieves the account from session if logged in.
 authenticated_by :: An array of strings for successful authentication methods for
                     the current session (e.g. password/remember/webauthn).
 possible_authentication_methods :: An array of strings for possible authentication

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -355,6 +355,10 @@ module Rodauth
       account_open_status_value
     end
 
+    def account!
+      account || (session_value && account_from_session)
+    end
+
     def account_from_session
       @account = _account_from_session
     end
@@ -680,7 +684,7 @@ module Rodauth
     # note that only the salt is returned.
     def get_password_hash
       if account_password_hash_column
-        (account || account_from_session)[account_password_hash_column]
+        account![account_password_hash_column]
       elsif use_database_authentication_functions?
         db.get(Sequel.function(function_name(:rodauth_get_salt), account ? account_id : session_value))
       else

--- a/lib/rodauth/features/verify_account_grace_period.rb
+++ b/lib/rodauth/features/verify_account_grace_period.rb
@@ -83,7 +83,7 @@ module Rodauth
     end
 
     def account_in_unverified_grace_period?
-      return false unless account || (session_value && account_from_session)
+      return false unless account!
       account[account_status_column] == account_unverified_status_value &&
         verify_account_grace_period &&
         !verify_account_ds.where(Sequel.date_add(verification_requested_at_column, :seconds=>verify_account_grace_period) > Sequel::CURRENT_TIMESTAMP).empty?

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -329,7 +329,7 @@ module Rodauth
     end
 
     def webauthn_user_name
-      (account || account_from_session)[login_column]
+      account![login_column]
     end
 
     def webauthn_origin

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -549,6 +549,28 @@ describe 'Rodauth' do
     page.find("#error_flash").text.must_equal "Please login to continue"
   end
 
+  it "should support retrieving current account" do
+    rodauth do
+      enable :login
+    end
+    roda do |r|
+      r.rodauth
+      r.root do
+        view :content=>"Current email: #{rodauth.account! && rodauth.account[:email]}"
+      end
+    end
+
+    visit "/"
+    page.body.must_include "Current email: \n"
+
+    login
+    page.body.must_include "Current email: foo@example.com"
+
+    instance = app.rodauth.allocate
+    instance.instance_eval { account_from_login("foo@example.com") }
+    instance.account![:email].must_equal "foo@example.com"
+  end
+
   it "should handle case where account is no longer valid during session" do
     rodauth do
       enable :login, :change_password


### PR DESCRIPTION
I find this method very convenient in other authentication frameworks, and have always wished for it to exist in Rodauth 🙂

In rodauth-rails, I provided an equivalent based on `#account_from_session`, but have recently run into a scenario where it doesn't work as expected. I could solve it in rodauth-rails, but I thought it would be useful to get it into Rodauth, as the logic is not Rails-specific.

The `#current_account` method retrieves the account record that's currently logged in, without regard to its status. This allows it to work when the account is unverified without grace period, which can happen when `create_account_autologin?` is set to `true`, and only verify_account feature is enabled. I wanted this setup because I'm working on a screencast where I'm rebuilding GitHub authentication using Rodauth, and this is how GitHub's account verification flow seems to work.

I also wanted to handle the case when a Rodauth instance has been allocated without a Roda instance and has `@account` set, which is the scenario in rodauth-rails when creating emails in a background job, where you just want to grab information for creating an email and don't need the internal_request feature.

I found a few places that could be simplified with the new `#current_account` method, so I updated those as well 🙂
