### PR TITLE
Extend remember deadline also while logged in

### DIFF
--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -30,13 +30,15 @@ for sessions autologged in via a remember token:
 
 == Auth Value Methods
 
-extend_remember_deadline? :: Whether to extend the remember token deadline when the user is autologged in via remember token.
+extend_remember_deadline? :: Whether to extend the remember token deadline every +extend_remember_deadline_period+ seconds.
+extend_remember_deadline_period :: The amount of seconds to wait before extending remember token deadline when +extend_remember_deadline?+ is true (3600 by default).
 raw_remember_token_deadline :: A deadline before which to allow a raw remember token to be used. Allows for graceful transition for when +hmac_secret+ is first set.
 remember_additional_form_tags :: HTML fragment containing additional form tags to use on the change remember setting form.
 remember_button :: The text to use for the change remember settings button.
 remember_cookie_key :: The cookie name to use for the remember token.
 remember_cookie_options :: Any options to set for the remember cookie. By default, the `:path` cookie option is set to `/` and `:httponly` is set to `true`. Also, `:secure` is set to `true` by default if the current request is an HTTPS request.
 remember_deadline_column :: The column name in the +remember_table+ storing the deadline after which the token will be ignored.
+remember_deadline_extended_session_key :: The session key set if the remember deadline token is being extended.
 remember_deadline_interval :: The amount of time for which to remember accounts, 14 days by default.  Only used if +set_deadline_values?+ is true.
 remember_disable_label :: The label for disabling remembering.
 remember_disable_param_value :: The parameter value for disabling remembering.


### PR DESCRIPTION
*Follow-up to https://github.com/jeremyevans/rodauth/discussions/311*

When extending remember deadline is turned on, this makes the user remembered for N days after their last activity, as opposed to since the last time they were autologged in via remember token. This behavior is probably closer to what the end user expects when asking the app to remember them.

To avoid executing an update on every request, we wait for a period of time before extending the remember deadline, 1 hour by default.
