### PR TITLE
Fix duplicate active sessions when creating and verifying account

### DIFF
--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -101,6 +101,7 @@ module Rodauth
     end
 
     def update_session
+      remove_current_session
       super
       add_active_session
     end


### PR DESCRIPTION
When verify_account_grace_period feature is logged in, when both `create_account_autologin?` and `verify_account_autologin?` are set to `true`. This means that when creating account and then verifying it, `#autologin_session` will be called twice. Since an active session is created on each `#update_session` call, the user will end up with two active sessions, with the second one being the current one. We fix this by removing the existing current session (if it exists) before proceeding to update the session.
