### PR TITLE
Logout no longer active session when remembered

### DIFF
--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -56,6 +56,8 @@ module Rodauth
 
     def no_longer_active_session
       clear_session
+      forget_login if respond_to?(:forget_login)
+
       set_redirect_error_status inactive_session_error_status
       set_error_reason :inactive_session
       set_redirect_error_flash active_sessions_error_flash

--- a/spec/active_sessions_spec.rb
+++ b/spec/active_sessions_spec.rb
@@ -207,6 +207,26 @@ describe 'Rodauth active sessions feature' do
     t.must_be(:<, Time.now - 10)
   end
 
+  it "should logout inactive session when using remember" do
+    rodauth do
+      enable :login, :active_sessions, :remember
+      hmac_secret '123'
+      after_login { remember_login }
+    end
+    roda do |r|
+      rodauth.check_active_session
+      rodauth.load_memory
+      r.rodauth
+      r.root{view :content=>rodauth.logged_in? ? "Logged In" : "Not Logged"}
+    end
+
+    login
+    DB[:account_active_session_keys].delete
+
+    visit '/'
+    page.body.must_include "Not Logged"
+  end
+
   it "should logout all sessions for account on logout if that option is selected" do
     rodauth do
       enable :login, :active_sessions


### PR DESCRIPTION
If calling both `rodauth.check_active_session` and `rodauth.load_memory` in the routing tree, when the session becomes no longer active, the user will not be logged out if remembered. This is because the user will be autologged back in from the remember cookie on first request after the session was cleared. We fix this by also forgetting the user when the session is found to no longer be active.
