### PR TITLE
Extract `remove_active_session(session_id)` method

### DIFF
--- a/doc/active_sessions.rdoc
+++ b/doc/active_sessions.rdoc
@@ -48,6 +48,7 @@ add_active_session :: Create a session id for the session and populate the sessi
 currently_active_session? :: Whether the session is currently active, by checking the database table.
 handle_duplicate_active_session_id(exception) :: How to handle the case where a duplicate session id for the account is inserted into the table.  Does nothing by default.  This should only be called if the random number generator is broken.
 no_longer_active_session :: What action to take if +rodauth.check_active_session+ is called and the session is no longer active.
+remove_active_session(session_id) :: Removes the active session matching the given session ID from the database. Useful for implementing session revoking.
 remove_all_active_sessions :: Remove all active session from the database, used for global logouts and when closing accounts.
 remove_current_session :: Remove current session from the database, used for regular logouts.
 remove_inactive_sessions :: Remove inactive sessions from the database, run before checking for whether the current session is active.

--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -29,6 +29,7 @@ module Rodauth
       :currently_active_session?,
       :handle_duplicate_active_session_id,
       :no_longer_active_session,
+      :remove_active_session,
       :remove_all_active_sessions,
       :remove_current_session,
       :remove_inactive_sessions,
@@ -82,8 +83,12 @@ module Rodauth
 
     def remove_current_session
       if session_id = session[session_id_session_key]
-        active_sessions_ds.where(active_sessions_session_id_column=>compute_hmac(session_id)).delete
+        remove_active_session(compute_hmac(session_id))
       end
+    end
+
+    def remove_active_session(session_id)
+      active_sessions_ds.where(active_sessions_session_id_column=>session_id).delete
     end
 
     def remove_all_active_sessions


### PR DESCRIPTION
This is useful when implementing session revoking, where we want to delete a specific session from the database that's not the current session, in order to log that browser out of the app.

This requires a HMAC'ed session ID, because it's intended to be called using a session ID retrieved from the database, which is HMAC'ed.
