### PR TITLE
Support :render=>false plugin option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Support :render=>false plugin options (davekaro)
+
 * Add remove_active_session method for removing the active session for a given session id (janko) (#317)
 
 * Remove current active session when adding new active session (janko) (#314) 

--- a/README.rdoc
+++ b/README.rdoc
@@ -79,7 +79,8 @@ There are some dependencies that Rodauth uses depending on the
 features in use. These are development dependencies instead of
 runtime dependencies in the gem as it is possible to run without them:
 
-tilt :: Used by all features unless in JSON API only mode.
+tilt :: Used by all features unless in JSON API only mode or using
+        :render=>false plugin option.
 rack_csrf :: Used for CSRF support if the <tt>csrf: :rack_csrf</tt> plugin
              option is given (the default is to use Roda's route_csrf
              plugin, as that allows for more secure request-specific
@@ -852,6 +853,8 @@ which configures which dependent plugins should be loaded. Options:
 :csrf :: Set to +false+ to not load a csrf plugin.  Set to +:rack_csrf+
          to use the csrf plugin instead of the route_csrf plugin.
 :flash :: Set to +false+ to not load the flash plugin
+:render :: Set to +false+ to not load the render plugin. This is useful
+           to avoid the dependency on tilt when using alternative view libaries.
 :json :: Set to +true+ to load the json and json_parser plugins. Set
          to +:only+ to only load those plugins and not any other plugins.
          Note that if you are enabling features that send email, you

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -22,8 +22,10 @@ module Rodauth
     end
 
     unless json_opt == :only
-      require 'tilt/string'
-      app.plugin :render
+      unless opts[:render] == false
+        require 'tilt/string'
+        app.plugin :render
+      end
 
       case opts.fetch(:csrf, app.opts[:rodauth_csrf])
       when false

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -758,11 +758,12 @@ describe 'Rodauth' do
     page.body.must_equal 'email id'
   end
 
-  it "should support :csrf=>false and :flash=>false plugin options" do
+  it "should support :csrf=>false and :flash=>false and :render=> false plugin options" do
     c = Class.new(Roda)
-    c.plugin(:rodauth, :csrf=>false, :flash=>false){}
+    c.plugin(:rodauth, :csrf=>false, :flash=>false, :render=>false){}
     c.route{}
     c.instance_variable_get(:@middleware).length.must_equal 0
+    c.ancestors.map(&:to_s).wont_include 'Roda::RodaPlugins::Render::InstanceMethods'
     c.ancestors.map(&:to_s).wont_include 'Roda::RodaPlugins::Flash::InstanceMethods'
     c.ancestors.map(&:to_s).wont_include 'Roda::RodaPlugins::RouteCsrf::InstanceMethods'
   end


### PR DESCRIPTION
This should be used if alternative view libraries will be provided. For example, if using Rodauth with Phlex to render HTML.