### PR TITLE
Remove unmatched </div>

### DIFF
--- a/demo-site/views/layout.erb
+++ b/demo-site/views/layout.erb
@@ -35,7 +35,6 @@ input.rodauth_hidden {
           <input class="btn btn-primary form-control auth-button" type="submit" value="Logout" />
         </form>
       <% end %>
-    </div>
   </div>
 </nav>
 


### PR DESCRIPTION
I was trying to run this through an erb auto formatter, and it crashed on this. Looking closely, emacs also noticed the unmatched `</div>`. Possibly the indentation in the surrounding code is a little weird and could be changed.