### PR TITLE
Add WebAuthn Autofill feature

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,7 @@ HTML and JSON API for all supported features.
 * WebAuthn (Multifactor authentication via WebAuthn)
 * WebAuthn Login (Passwordless login via WebAuthn)
 * WebAuthn Verify Account (Passwordless WebAuthn Setup)
+* WebAuthn Autofill (Autofill WebAuthn credentials on login)
 * OTP (Multifactor authentication via TOTP)
 * Recovery Codes (Multifactor authentication via backup codes)
 * SMS Codes (Multifactor authentication via SMS)
@@ -932,6 +933,7 @@ view the appropriate file in the doc directory.
 * {Verify Account Grace Period}[rdoc-ref:doc/verify_account_grace_period.rdoc]
 * {Verify Login Change}[rdoc-ref:doc/verify_login_change.rdoc]
 * {WebAuthn}[rdoc-ref:doc/webauthn.rdoc]
+* {WebAuthn Autofill}[rdoc-ref:doc/webauthn_autofill.rdoc]
 * {WebAuthn Login}[rdoc-ref:doc/webauthn_login.rdoc]
 * {WebAuthn Verify Account}[rdoc-ref:doc/webauthn_verify_account.rdoc]
 

--- a/demo-site/rodauth_demo.rb
+++ b/demo-site/rodauth_demo.rb
@@ -56,6 +56,7 @@ class App < Roda
            :email_auth
     enable :webauthn, :webauthn_login if ENV["RODAUTH_WEBAUTHN"]
     enable :webauthn_verify_account if ENV["RODAUTH_WEBAUTHN_VERIFY_ACCOUNT"]
+    enable :webauthn_autofill if ENV["RODAUTH_WEBAUTHN_AUTOFILL"]
     max_invalid_logins 2
     account_password_hash_column :ph
     title_instance_variable :@page_title

--- a/doc/webauthn_autofill.rdoc
+++ b/doc/webauthn_autofill.rdoc
@@ -1,0 +1,14 @@
+= Documentation for WebAuthn Autofill Feature
+
+The webauthn_autofill feature enables autofill UI (aka "conditional mediation")
+for WebAuthn credentials, logging the user in on selection. It depends on the
+webauthn_login feature.
+
+== Auth Value Methods
+
+webauthn_autofill_js :: The javascript code to execute on the login page to enable autofill UI.
+webauthn_autofill_js_route :: The route to the webauthn autofill javascript file.
+
+== Auth Methods
+
+before_webauthn_autofill_js_route :: Run arbitrary code before handling a webauthn autofill javascript route.

--- a/doc/webauthn_login.rdoc
+++ b/doc/webauthn_login.rdoc
@@ -1,6 +1,6 @@
 = Documentation for WebAuthn Login Feature
 
-The webauthn feature implements passwordless authentication via
+The webauthn_login feature implements passwordless authentication via
 WebAuthn. It depends on the login and webauthn features.
 
 == Auth Value Methods

--- a/doc/webauthn_verify_account.rdoc
+++ b/doc/webauthn_verify_account.rdoc
@@ -1,6 +1,6 @@
 = Documentation for WebAuthn Verify Account Feature
 
-The webauthn feature implements setting up an WebAuthn authenticator
+The webauthn_verify_account feature implements setting up an WebAuthn authenticator
 during the account verification process, and making such setup
 a requirement for account verification.  By default, it disables
 asking for a password during account creation and verification,

--- a/javascript/webauthn_autofill.js
+++ b/javascript/webauthn_autofill.js
@@ -1,0 +1,38 @@
+(function() {
+  var pack = function(v) { return btoa(String.fromCharCode.apply(null, new Uint8Array(v))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''); };
+  var unpack = function(v) { return Uint8Array.from(atob(v.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)); };
+  var element = document.getElementById('webauthn-login-form');
+
+  if (!window.PublicKeyCredential || !PublicKeyCredential.isConditionalMediationAvailable) return;
+
+  PublicKeyCredential.isConditionalMediationAvailable().then(function(available) {
+    if (!available) return;
+
+    var opts = JSON.parse(element.getAttribute("data-credential-options"));
+    opts.challenge = unpack(opts.challenge);
+    opts.allowCredentials.forEach(function(cred) { cred.id = unpack(cred.id); });
+
+    navigator.credentials.get({mediation: "conditional", publicKey: opts}).then(function(cred) {
+      var rawId = pack(cred.rawId);
+      var authValue = {
+        type: cred.type,
+        id: rawId,
+        rawId: rawId,
+        response: {
+          authenticatorData: pack(cred.response.authenticatorData),
+          clientDataJSON: pack(cred.response.clientDataJSON),
+          signature: pack(cred.response.signature)
+        }
+      };
+
+      if (cred.response.userHandle) {
+        authValue.response.userHandle = pack(cred.response.userHandle);
+      }
+
+      document.getElementById('webauthn-auth').value = JSON.stringify(authValue);
+
+      element.submit();
+    });
+  });
+})();
+

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -269,6 +269,10 @@ module Rodauth
       Sequel::DATABASES.first or raise "Sequel database connection is missing"
     end
 
+    def login_field_autocomplete_value
+      login_uses_email? ? "email" : "on"
+    end
+
     def password_field_autocomplete_value
       @password_field_autocomplete_value || 'current-password'
     end

--- a/lib/rodauth/features/json.rb
+++ b/lib/rodauth/features/json.rb
@@ -116,7 +116,7 @@ module Rodauth
 
     def before_webauthn_login_route
       super if defined?(super)
-      if use_json? && !param_or_nil(webauthn_auth_param) && account_from_login(param(login_param))
+      if use_json? && !param_or_nil(webauthn_auth_param) && webauthn_login_options?
         cred = webauthn_credential_options_for_get
         json_response[webauthn_auth_param] = cred.as_json
         json_response[webauthn_auth_challenge_param] = cred.challenge

--- a/lib/rodauth/features/webauthn_autofill.rb
+++ b/lib/rodauth/features/webauthn_autofill.rb
@@ -1,0 +1,58 @@
+# frozen-string-literal: true
+
+module Rodauth
+  Feature.define(:webauthn_autofill, :WebauthnAutofill) do
+    depends :webauthn_login
+
+    auth_value_method :webauthn_autofill_js, File.binread(File.expand_path('../../../../javascript/webauthn_autofill.js', __FILE__)).freeze
+
+    route(:webauthn_autofill_js) do |r|
+      before_webauthn_autofill_js_route
+      r.get do
+        response['Content-Type'] = 'text/javascript'
+        webauthn_autofill_js
+      end
+    end
+
+    def webauthn_allow
+      return [] unless logged_in? || account
+      super
+    end
+
+    def webauthn_user_verification
+      'preferred'
+    end
+
+    def webauthn_authenticator_selection
+      super.merge({ 'residentKey' => 'required', 'requireResidentKey' => true })
+    end
+
+    def login_field_autocomplete_value
+      request.path_info == login_path ? "#{super} webauthn" : super
+    end
+
+    private
+
+    def _login_form_footer
+      footer = super
+      footer += render("webauthn-autofill") unless valid_login_entered?
+      footer
+    end
+
+    def account_from_webauthn_login
+      return super if param_or_nil(login_param)
+
+      credential_id = webauthn_auth_data["id"]
+      account_id = db[webauthn_keys_table]
+        .where(webauthn_keys_webauthn_id_column => credential_id)
+        .get(webauthn_keys_account_id_column)
+
+      @account = account_ds(account_id).first if account_id
+    end
+
+    def webauthn_login_options?
+      return true unless param_or_nil(login_param)
+      super
+    end
+  end
+end

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -16,7 +16,7 @@ module Rodauth
 
       r.post do
         catch_error do
-          unless account_from_login(param(login_param)) && open_account?
+          unless account_from_webauthn_login && open_account?
             throw_error_reason(:no_matching_login, no_matching_login_error_status, login_param, no_matching_login_message) 
           end
 
@@ -53,6 +53,14 @@ module Rodauth
     end
 
     private
+
+    def account_from_webauthn_login
+      account_from_login(param(login_param))
+    end
+
+    def webauthn_login_options?
+      account_from_login(param(login_param))
+    end
 
     def _multi_phase_login_forms
       forms = super

--- a/spec/webauthn_autofill_spec.rb
+++ b/spec/webauthn_autofill_spec.rb
@@ -1,0 +1,131 @@
+require_relative 'spec_helper'
+
+begin
+  require 'webauthn/fake_client'
+rescue LoadError
+else
+describe 'Rodauth webauthn_autofill feature' do
+  it "should handle autofill on login via WebAuthn" do
+    rodauth do
+      enable :logout, :webauthn_autofill, :create_account
+      hmac_secret '123'
+    end
+    first_request = nil
+    roda do |r|
+      first_request ||= r
+      r.rodauth
+
+      if rodauth.logged_in?
+        view :content=>"Logged In via #{rodauth.authenticated_by.join(' and ')}"
+      else
+        view :content=>"Not Logged In"
+      end
+    end
+
+    visit '/'
+    page.html.must_include 'Not Logged In'
+
+    origin = first_request.base_url
+    webauthn_client = WebAuthn::FakeClient.new(origin)
+
+    visit '/login'
+    fill_in 'Login', :with=>'foo@example.com'
+    click_button 'Login'
+    fill_in 'Password', :with=>'0123456789'
+    click_button 'Login'
+    page.html.must_include 'Logged In via password'
+
+    visit '/webauthn-setup'
+    challenge = JSON.parse(page.find('#webauthn-setup-form')['data-credential-options'])['challenge']
+    fill_in 'Password', :with=>'0123456789'
+    fill_in 'webauthn_setup', :with=>webauthn_client.create(challenge: challenge).to_json
+    click_button 'Setup WebAuthn Authentication'
+    page.find('#notice_flash').text.must_equal 'WebAuthn authentication is now setup'
+    page.current_path.must_equal '/'
+    page.html.must_include 'Logged In via password and webauthn'
+
+    logout
+
+    visit '/login'
+    page.find("#login")[:autocomplete].must_equal "email webauthn"
+    challenge = JSON.parse(page.find('#webauthn-login-form')['data-credential-options'])['challenge']
+    fill_in 'webauthn_auth', :with=>webauthn_client.get(challenge: challenge).to_json
+    click_button 'Authenticate Using WebAuthn'
+    page.find('#notice_flash').text.must_equal "You have been logged in"
+    page.current_path.must_equal '/'
+    page.html.must_include 'Logged In via webauthn'
+
+    logout
+
+    visit '/login'
+    fill_in 'Login', :with=>'foo@example.com'
+    click_button 'Login'
+    challenge = JSON.parse(page.find('#webauthn-auth-form')['data-credential-options'])['challenge']
+    fill_in 'webauthn_auth', :with=>webauthn_client.get(challenge: challenge).to_json
+    click_button 'Authenticate Using WebAuthn'
+    page.find('#notice_flash').text.must_equal 'You have been logged in'
+    page.current_path.must_equal '/'
+    page.html.must_include 'Logged In via webauthn'
+
+    logout
+
+    DB[:account_webauthn_keys].delete
+    visit '/login'
+    challenge = JSON.parse(page.find('#webauthn-login-form')['data-credential-options'])['challenge']
+    fill_in 'webauthn_auth', :with=>webauthn_client.get(challenge: challenge).to_json
+    click_button 'Authenticate Using WebAuthn'
+    page.find('#error_flash').text.must_equal "There was an error authenticating via WebAuthn"
+    page.current_path.must_equal '/login'
+
+    visit '/webauthn-autofill-js'
+    page.body.must_include File.binread("javascript/webauthn_autofill.js")
+
+    visit '/create-account'
+    page.find("#login")[:autocomplete].must_equal "email"
+  end
+
+  it "should allow webauthn autofill via json" do
+    rodauth do
+      enable :webauthn_autofill, :logout
+      hmac_secret '123'
+    end
+    first_request = nil
+    roda(:json) do |r|
+      first_request ||= r
+      r.rodauth
+      rodauth.authenticated_by || ['']
+    end
+
+    json_request.must_equal [200, ['']]
+    json_login
+    json_request.must_equal [200, ['password']]
+
+    origin = first_request.base_url
+    webauthn_client = WebAuthn::FakeClient.new(origin)
+
+    res = json_request('/webauthn-setup', :password=>'0123456789')
+    setup_json = res[1].delete("webauthn_setup")
+    challenge = res[1].delete("webauthn_setup_challenge")
+    challenge_hmac = res[1].delete("webauthn_setup_challenge_hmac")
+    webauthn_hash = webauthn_client.create(challenge: setup_json['challenge'])
+    res = json_request('/webauthn-setup', :password=>'0123456789', :webauthn_setup=>webauthn_hash, :webauthn_setup_challenge=>challenge, :webauthn_setup_challenge_hmac=>challenge_hmac)
+    res.must_equal [200, {'success'=>'WebAuthn authentication is now setup'}]
+
+    json_logout
+    json_request.must_equal [200, ['']]
+
+    res = json_request('/webauthn-login', :login=>'foo@example.com')
+    res[1]["webauthn_auth"]["allowCredentials"].wont_equal []
+
+    res = json_request('/webauthn-login')
+    auth_json = res[1].delete("webauthn_auth")
+    challenge = res[1].delete("webauthn_auth_challenge")
+    challenge_hmac = res[1].delete("webauthn_auth_challenge_hmac")
+    res.must_equal [422, {"field-error"=>["webauthn_auth", "invalid webauthn authentication param"], "error"=>"There was an error authenticating via WebAuthn", "reason"=>"invalid_webauthn_auth_param"}]
+
+    res = json_request('/webauthn-login', :webauthn_auth=>webauthn_client.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
+    res.must_equal [200, {'success'=>'You have been logged in'}]
+    json_request.must_equal [200, ['webauthn']]
+  end
+end
+end

--- a/templates/login-field.str
+++ b/templates/login-field.str
@@ -1,4 +1,4 @@
 <div class="form-group mb-3">
   <label for="login" class="form-label">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
-  #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_uses_email? ? "email" : "on")}
+  #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_field_autocomplete_value)}
 </div>

--- a/templates/webauthn-autofill.str
+++ b/templates/webauthn-autofill.str
@@ -1,0 +1,9 @@
+<form method="post" action="#{rodauth.webauthn_login_path}" class="rodauth" role="form" id="webauthn-login-form" data-credential-options="#{h((cred = rodauth.webauthn_credential_options_for_get).as_json.to_json)}">
+  #{rodauth.webauthn_auth_additional_form_tags}
+  #{rodauth.csrf_tag(rodauth.webauthn_login_path)}
+  <input type="hidden" name="#{rodauth.webauthn_auth_challenge_param}" value="#{cred.challenge}" />
+  <input type="hidden" name="#{rodauth.webauthn_auth_challenge_hmac_param}" value="#{rodauth.compute_hmac(cred.challenge)}" />
+  <input class="rodauth_hidden d-none" aria-hidden="true" type="text" name="#{rodauth.webauthn_auth_param}" id="webauthn-auth" value="" />
+  #{rodauth.button(rodauth.webauthn_auth_button, class: "d-none")}
+</form>
+<script src="#{rodauth.webauthn_js_host}#{rodauth.webauthn_autofill_js_path}"></script>

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -53,6 +53,7 @@
   <li><a href="rdoc/files/doc/verify_account_grace_period_rdoc.html">Verify Account Grace Period</a>: Allows newly created accounts a grace period before verification is required.</li>
   <li><a href="rdoc/files/doc/verify_login_change_rdoc.html">Verify Login Change</a>: Requires verification of new logins before changing logins.</li>
   <li><a href="rdoc/files/doc/webauthn_rdoc.html">WebAuthn</a>: Adds support for multifactor authentication via WebAuthn.</li>
+  <li><a href="rdoc/files/doc/webauthn_autofill_rdoc.html">WebAuthn Autofill</a>: Enables autofill UI for WebAuthn credentials on login.</li>
   <li><a href="rdoc/files/doc/webauthn_login_rdoc.html">WebAuthn Login</a>: Adds support for passwordless login via WebAuthn.</li>
   <li><a href="rdoc/files/doc/webauthn_verify_account_rdoc.html">WebAuthn Verify Account</a>: Adds support for passwordless WebAuthn setup during account verification.</li>
 </ul>

--- a/www/pages/why.erb
+++ b/www/pages/why.erb
@@ -55,8 +55,9 @@
   <li>Audit Logging</li>
   <li>Email Authentication (Passwordless login via email link)</li>
   <li>WebAuthn (Multifactor authentication via WebAuthn)</li>
-  <li>Webauthn Login (Passwordless login via WebAuthn)</li>
-  <li>Webauthn Verify Account (Passwordless WebAuthn Setup)</li>
+  <li>WebAuthn Login (Passwordless login via WebAuthn)</li>
+  <li>WebAuthn Verify Account (Passwordless WebAuthn Setup)</li>
+  <li>WebAuthn Autofill (Autofill WebAuthn credentials on login)</li>
   <li>OTP (Multifactor authentication via TOTP)</li>
   <li>Recovery Codes (Multifactor authentication via backup codes)</li>
   <li>SMS Codes (Multifactor authentication via SMS)</li>


### PR DESCRIPTION
This feature activates the [autofill UI](https://passkeys.dev/docs/reference/terms/#autofill-ui) for passkeys that the browser has stored on the login page, allowing the user to skip entering their email address or submitting the login form. It implements the same UX seen in https://webauthn.io/.

It builds on top of the WebAuthn Login feature, reusing its login endpoint. It ships with separate JavaScript that activates the autofill UI on the login page, and automatically submits the WebAuthn login form when the user selects their passkey. The WebAuthn login route then retrieves the user from the WebAuthn credential ID.

This requires requires the autocomplete attribute on login field to include `webauthn`. We now need to generate WebAuthn options without first identifying the account, so we handle that. The passkeys.dev website recommends asking for user verification preferred and discoverable credentials, so we change that as well.

The WebAuthn autofill form is mostly the same as the WebAuthn auth form, except that it loads different JS, doesn't have the login field, and hides the submit button to make the form invisible, since it's meant to be submitted internally by the JS.

https://user-images.githubusercontent.com/795488/228453630-318a8bed-4e36-4802-be52-180059077811.mp4