### PR TITLE
Replaced Array#pack with Base64.urlsafe_encode64 in specs for generating authorization header

### DIFF
--- a/spec/http_basic_auth_spec.rb
+++ b/spec/http_basic_auth_spec.rb
@@ -7,7 +7,7 @@ describe "Rodauth http basic auth feature" do
   end
 
   def authorization_header(opts={})
-    ["#{opts.delete(:username)||'foo@example.com'}:#{opts.delete(:password)||'0123456789'}"].pack("m*")
+    Base64.urlsafe_encode64 "#{opts.delete(:username)||'foo@example.com'}:#{opts.delete(:password)||'0123456789'}"
   end
 
   def basic_auth_json_request(opts={})


### PR DESCRIPTION
Current implementation of Authorization header in specs may produce not URL-safe. I found this in [rodauth-oauth](https://gitlab.com/os85/rodauth-oauth/-/merge_requests/121), but this also applies to Rodauth.