### PR TITLE
Mention active_sessions in JWT feature docs

### DIFF
--- a/doc/jwt.rdoc
+++ b/doc/jwt.rdoc
@@ -5,7 +5,7 @@ that ship with Rodauth, using JWT (JSON Web Tokens) to hold the
 session information. It depends on the json feature.
 
 In order to use this feature, you have to set the +jwt_secret+ configuration
-option the secret used to cryptographically protect the token.
+option with the secret used to cryptographically protect the token.
 
 To use this JSON API, when processing responses for requests to a Rodauth
 endpoint, check for the Authorization header, and use the value of the
@@ -25,6 +25,11 @@ If you would like to check if a valid JWT was submitted with the current
 request in your Roda app, you can call the +rodauth.valid_jwt?+ method.  If
 +rodauth.valid_jwt?+ returns true, the contents of the jwt can be retrieved
 from +rodauth.session+.
+
+Logging the session out does not invalidate the previous JWT token by default.
+If you would like this behavior, you can use the active_sessions feature, which
+stores session identifiers in the database and deletes them when the session
+expires. This provides a whitelist approach of revoking JWT tokens.
 
 == Auth Value Methods
 

--- a/doc/jwt_refresh.rdoc
+++ b/doc/jwt_refresh.rdoc
@@ -7,7 +7,7 @@ When this feature is used, the access and refresh token are provided
 at login in the response body (the access token is still provided in the Authorization
 header), and for any subsequent POST to <tt>/jwt-refresh</tt>.
 
-Note that using the refresh token invalides the token and creates
+Note that using the refresh token invalidates the token and creates
 a new access token with an updated lifetime.  However, it does not invalidate
 older access tokens.  Older access tokens remain valid until they expire.  You
 can use the active_sessions feature if you want previous access tokens to be invalid


### PR DESCRIPTION
It's already mentioned in JWT Refresh docs, but it also works just with JWT, so I thought it's good to mention it there as well. We clarify that this implements the whitelist approach to revoking JWT tokens.
