### PR TITLE
Added rackup dependency for Rack 3 compatibility

### DIFF
--- a/rodauth.gemspec
+++ b/rodauth.gemspec
@@ -49,6 +49,7 @@ END
   s.add_dependency('roda', [">= 2.6.0"])
   s.add_development_dependency('tilt')
   s.add_development_dependency('rack_csrf')
+  s.add_development_dependency('rackup')
   s.add_development_dependency('bcrypt')
   s.add_development_dependency('argon2', '>=2')
   s.add_development_dependency('mail')

--- a/www/config.ru
+++ b/www/config.ru
@@ -1,2 +1,4 @@
+require 'rack/static'
+
 use Rack::Static, :urls=>%w'/index.html /why.html /documentation.html /development.html /css /images /rdoc', :root=>'public'
 run proc{[302, {'Content-Type'=>'text/html', 'Location'=>'index.html'}, []]}


### PR DESCRIPTION
## Description

In Rack 3 `bin/rackup` (that is used to serve local version of documentation) has been moved to a separate gem: https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#binrackup-rackserver-rackhandlerand--racklobster-were-moved-to-a-separate-gem.