### PR TITLE
Allow explicit usage of `p_cost` in argon2 feature.

### DIFF
--- a/lib/rodauth/features/argon2.rb
+++ b/lib/rodauth/features/argon2.rb
@@ -43,7 +43,7 @@ module Rodauth
 
     def password_hash_cost
       return super unless use_argon2?
-      argon2_hash_cost 
+      argon2_hash_cost
     end
 
     def password_hash_match?(hash, password)
@@ -63,18 +63,18 @@ module Rodauth
     def extract_password_hash_cost(hash)
       return super unless argon2_hash_algorithm?(hash )
 
-      /\A\$argon2id\$v=\d+\$m=(\d+),t=(\d+)/ =~ hash
-      { t_cost: $2.to_i, m_cost: Math.log2($1.to_i).to_i }
+      /\A\$argon2id\$v=\d+\$m=(\d+),t=(\d+),p=(\d+)/ =~ hash
+      { t_cost: $2.to_i, m_cost: Math.log2($1.to_i).to_i, p_cost: $3.to_i }
     end
 
     if ENV['RACK_ENV'] == 'test'
       def argon2_hash_cost
-        {t_cost: 1, m_cost: 3}
+        { t_cost: 1, m_cost: 3, p_cost: 1 }
       end
     # :nocov:
     else
       def argon2_hash_cost
-        {t_cost: 2, m_cost: 16}
+        { t_cost: 2, m_cost: 16, p_cost: 1 }
       end
     end
     # :nocov:

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -418,9 +418,9 @@ describe 'Rodauth login feature' do
           it "should be able to login #{use_secret ? 'with' : 'without'} argon2 secret" do
             rodauth do
               enable :argon2, :login, :create_account, :logout
-              argon2_secret 'secret' if use_secret
 
               # Custom p_cost of 8
+              argon2_secret 'secret' if use_secret
               password_hash_cost({ t_cost: 2, m_cost: 16, p_cost: 8 })
             end
 
@@ -430,25 +430,120 @@ describe 'Rodauth login feature' do
             end
 
             # We verify that we can create an account with custom cost configuration
+            login = 'baz@example.com'
+            pass = 'Abc123*'
+
             visit '/create-account'
-            fill_in 'Login', :with=>'baz@example.com'
-            fill_in 'Confirm Login', :with=>'baz@example.com'
-            fill_in 'Password', :with=>'abcdefghi123*'
-            fill_in 'Confirm Password', :with=>'abcdefghi123*'
+            fill_in 'Login', with: login
+            fill_in 'Confirm Login', with: login
+            fill_in 'Password', with: pass
+            fill_in 'Confirm Password', with: pass
             click_on 'Create Account'
             page.find('#notice_flash').text.must_equal "Your account has been created"
 
             logout
 
             # We verify that we can login with the custom config
-            login(:login=>'bar@example.com')
+            login(login: login, pass: pass)
+
             page.find('#notice_flash').text.must_equal 'You have been logged in'
 
             logout
 
             # We verify that subsequent logins keep working as well
-            login(:login=>'bar@example.com')
+            login(login: login, pass: pass)
             page.find('#notice_flash').text.must_equal 'You have been logged in'
+          end
+
+          describe 'and existing argon2 passwords exists with custom hash costs' do
+            it 'should be able to login even if the hash cost changes' do
+              custom_cost = { t_cost: 2, m_cost: 16, p_cost: 8 }
+
+              rodauth do
+                enable :argon2, :login, :create_account, :logout
+
+                # Custom p_cost of 8
+                argon2_secret 'secret'
+                password_hash_cost { custom_cost }
+              end
+
+              roda do |r|
+                r.rodauth
+                r.root { view :content=>"Logged in" }
+              end
+
+              # We verify that we can create an account with custom cost configuration
+              login = 'baz@example.com'
+              pass = 'Abc123*'
+
+              visit '/create-account'
+              fill_in 'Login', with: login
+              fill_in 'Confirm Login', with: login
+              fill_in 'Password', with: pass
+              fill_in 'Confirm Password', with: pass
+              click_on 'Create Account'
+              page.find('#notice_flash').text.must_equal "Your account has been created"
+
+              logout
+
+              # We verify that we can login with the custom config
+              login(login: login, pass: pass)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+
+              # change hash cost and try to login again
+              custom_cost = { t_cost: 1, m_cost: 3, p_cost: 1 }
+
+              login(login: login, pass: pass)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+
+              # create new user with new hash cost and test login with both users
+              login_2 = 'dogs@example.com'
+              pass_2 = 'woofWoof123*'
+              visit '/create-account'
+              fill_in 'Login', with: login_2
+              fill_in 'Confirm Login', with: login_2
+              fill_in 'Password', with: pass_2
+              fill_in 'Confirm Password', with: pass_2
+              click_on 'Create Account'
+              page.find('#notice_flash').text.must_equal "Your account has been created"
+
+              # First user
+              login(login: login, pass: pass)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+
+              # Second user
+              login(login: login_2, pass: pass_2)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+
+              # bring custom cost to previous values and test both users
+              custom_cost = { t_cost: 2, m_cost: 16, p_cost: 8 }
+
+              # First user
+              login(login: login, pass: pass)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+
+              # Second user
+              login(login: login_2, pass: pass_2)
+
+              page.find('#notice_flash').text.must_equal 'You have been logged in'
+
+              logout
+            end
           end
         end
       end

--- a/spec/update_password_hash_spec.rb
+++ b/spec/update_password_hash_spec.rb
@@ -4,7 +4,7 @@ describe 'Rodauth update_password feature' do
   [false, true].each do |ph|
     it "should support updating passwords for accounts #{'with account_password_hash_column' if ph} if hash cost changes" do
       if RODAUTH_ALWAYS_ARGON2
-        cost = {t_cost: 1, m_cost: 3}
+        cost = {t_cost: 1, m_cost: 4, p_cost: 2}
       else
         cost = BCrypt::Engine::MIN_COST
       end
@@ -29,7 +29,7 @@ describe 'Rodauth update_password feature' do
       content.must_equal page.html
 
       if RODAUTH_ALWAYS_ARGON2
-        cost = {t_cost: 1, m_cost: 4}
+        cost = {t_cost: 1, m_cost: 4, p_cost: 2}
       else
         cost += 1
       end
@@ -103,7 +103,7 @@ end
 describe 'Rodauth update_password feature' do
   around(:all) do |&block|
     DB.transaction(:rollback=>:always) do
-      hasher = ::Argon2::Password.new({ t_cost: 1, m_cost: 3 })
+      hasher = ::Argon2::Password.new({ t_cost: 1, m_cost: 4, p_cost: 2 })
       hash = hasher.create('01234567')
       DB[PASSWORD_HASH_TABLE].insert(:id=>DB[:accounts].insert(:email=>'foo2@example.com', :status_id=>2, :ph=>hash), :password_hash=>hash)
       super(&block)
@@ -112,7 +112,7 @@ describe 'Rodauth update_password feature' do
 
   [false, true].each do |ph|
     it "should support updating passwords for accounts #{'with account_password_hash_column' if ph} if hash cost changes via argon2" do
-      cost = { t_cost: 1, m_cost: 3 }
+      cost = { t_cost: 1, m_cost: 4, p_cost: 2 }
       rodauth do
         enable :login, :logout, :update_password_hash, :argon2
         account_password_hash_column :ph if ph
@@ -133,7 +133,7 @@ describe 'Rodauth update_password feature' do
       page.current_path.must_equal '/'
       content.must_equal page.html
 
-      cost = { t_cost: 2, m_cost: 3 }
+      cost = { t_cost: 2, m_cost: 4, p_cost: 2 }
       logout
       login(:login=>'foo2@example.com', :pass=>'01234567')
       new_content = page.html


### PR DESCRIPTION
Based on a discussion on #349 where I ran into a small issue when a custom hash cost for argon2 was specified, this PR implements the explicit usage of the `p_cost` attribute that can be defined when hashing passwords with this particular algorithm.

I didn't run any linter on my changes as I'm not sure which one is used or if there's some specific configuration I need to have.

All test passed on postgresql and ruby 3.2.2, but I can try other versions/databases if needed.