### PR TITLE
Allow WebAuthn login to count for two factors

### DIFF
--- a/doc/webauthn_login.rdoc
+++ b/doc/webauthn_login.rdoc
@@ -5,6 +5,7 @@ WebAuthn. It depends on the login and webauthn features.
 
 == Auth Value Methods
 
+webauthn_login_user_verification_additional_factor? :: Whether passwordless login via WebAuthn should consider user verification as 2nd factor when using multifactor authentication, false by default.
 webauthn_login_error_flash :: The flash error to show if there is a failure during passwordless login via WebAuthn.
 webauthn_login_failure_redirect :: Whether to redirect if there is a failure during passwordless login via WebAuthn.
 webauthn_login_route :: The route to the webauthn login action.


### PR DESCRIPTION
From the [FIDO Alliance website](allow-webauthn-to-count-for-two-factors):

> **Are passkeys considered multi-factor authentication?**
>
> Passkeys are kept on a user’s devices (something the user “has”) and — if the RP requests User Verification — can only be exercised by the user with a biometric or PIN (something the user “is” or ”knows”). Thus, authentication with passkeys embodies the core principle of multi-factor security.

To allow passwordless login via a passkey to be counted for two factors, we add a new `webauthn_login_two_factors?` configuration option, which when set to true will consider the user two-factor authenticated if they're using multifactor authentication.

This is useful for skipping classic 2nd factor methods such as TOTP, recovery codes or SMS codes, but it's especially useful when the account has a password or email_auth is enabled, both of which are considered additional factors, and would normally be required after WebAuthn login.

In this case, `webauthn_user_verification` should probably be set to `preferred` (set by `webauthn_autofill` feature) or `required`, rather than `discouraged` set by `webauthn` feature. Though, even with `discouraged` user verification, my Mac and iPhone still ask for biometric identification.