### PR TITLE
Add internal request support for WebAuthn

### DIFF
--- a/doc/internal_request.rdoc
+++ b/doc/internal_request.rdoc
@@ -461,3 +461,79 @@ account login, before the change.
 
 Options:
 +:verify_login_change_key+ :: The verify login change key for the account. This allows verifying login changes by key, without knowing the account id or login.
+
+=== WebAuthn
+
+==== webauthn_setup_params (requires account)
+
+The +webauthn_setup_params+ method returns a hash with +:webauthn_setup+,
++:webauthn_setup_challenge+ and +:webauthn_setup_challenge_hmac+ keys.
+
+The +:webauthn_setup+ options should be provided to the client for WebAuthn
+registration, while +:webauthn_setup_challenge+ and
++webauthn_setup_challenge_hmac+ should be passed to the +webauthn_setup+
+method.
+
+==== webauthn_setup (requires account)
+
+The +webauthn_setup+ method creates a WebAuthn credential for the account.
+
+Options:
++:webauthn_setup+ :: The WebAuthn credential provided by the client during registration.
++:webauthn_setup_challenge+ :: The WebAuthn challenge generated for registration.
++:webauthn_setup_challenge_hmac+ :: The HMAC of the WebAuthn challenge generated for registration.
+
+==== webauthn_auth_params (requires account)
+
+The +webauthn_auth_params+ method returns a hash with +:webauthn_auth+,
++:webauthn_auth_challenge+ and +:webauthn_auth_challenge_hmac+ keys.
+
+The +:webauthn_auth+ options should be provided to the client for WebAuthn
+authentication, while +:webauthn_auth_challenge+ and
++webauthn_auth_challenge_hmac+ should be passed to the +webauthn_auth+ method.
+
+==== webauthn_auth (requires account)
+
+The +webauthn_auth+ method determines if the given WebAuthn credential is valid
+for the account.
+
+Options:
++:webauthn_auth+ :: The WebAuthn credential provided by the client during authentication.
++:webauthn_auth_challenge+ :: The WebAuthn challenge generated for authentication.
++:webauthn_auth_challenge_hmac+ :: The HMAC of the WebAuthn challenge generated for authentication.
+
+==== webauthn_remove (requires account)
+
+The +webauthn_remove+ methods deletes the given WebAuthn credential for the
+account.
+
+Options:
++:webauthn_remove+ :: The ID of the WebAuthn credential to delete.
+
+=== WebAuthn Login
+
+==== webauthn_login_params (requires account or login)
+
+The +webauthn_login_params+ method returns a hash with +:webauthn_auth+,
++:webauthn_auth_challenge+ and +:webauthn_auth_challenge_hmac+ keys.
+
+The +:webauthn_auth+ options should be provided to the client for WebAuthn
+authentication, while +:webauthn_auth_challenge+ and
++webauthn_auth_challenge_hmac+ should be passed to the +webauthn_login+ method.
+
+==== webauthn_login (requires account or login)
+
+The +webauthn_login+ method determines if the given WebAuthn credential is
+valid for the given account.
+
+This method will return the account id if the WebAuthn credential is valid.
+
+Options:
++:webauthn_auth+ :: The WebAuthn credential provided by the client during authentication.
++:webauthn_auth_challenge+ :: The WebAuthn challenge generated for authentication.
++:webauthn_auth_challenge_hmac+ :: The HMAC of the WebAuthn challenge generated for authentication.
+
+=== WebAuthn Autofill
+
+Enabling this feature modifies +webauthn_login_params+ and +webauthn_login+
+methods not to require an account or login.

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -112,6 +112,12 @@ module Rodauth
 
     def_deprecated_alias :webauthn_credential_options_for_get, :webauth_credential_options_for_get
 
+    internal_request_method :webauthn_setup_params
+    internal_request_method :webauthn_setup
+    internal_request_method :webauthn_auth_params
+    internal_request_method :webauthn_auth
+    internal_request_method :webauthn_remove
+
     route(:webauthn_auth_js) do |r|
       before_webauthn_auth_js_route
       r.get do

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -12,6 +12,9 @@ module Rodauth
 
     auth_value_method :webauthn_login_user_verification_additional_factor?, false
 
+    internal_request_method :webauthn_login_params
+    internal_request_method :webauthn_login
+
     route(:webauthn_login) do |r|
       check_already_logged_in
       before_webauthn_login_route

--- a/spec/webauthn_autofill_spec.rb
+++ b/spec/webauthn_autofill_spec.rb
@@ -127,5 +127,36 @@ describe 'Rodauth webauthn_autofill feature' do
     res.must_equal [200, {'success'=>'You have been logged in'}]
     json_request.must_equal [200, ['webauthn']]
   end
+
+  it "should support webauthn autofill using internal requests" do
+    rodauth do
+      enable :webauthn_autofill, :internal_request
+      hmac_secret '123'
+      domain "example.com"
+    end
+    roda do |r|
+    end
+
+    webauthn_client = WebAuthn::FakeClient.new("https://example.com")
+
+    setup_params = app.rodauth.webauthn_setup_params(account_login: 'foo@example.com')
+    app.rodauth.webauthn_setup(
+      account_login: 'foo@example.com',
+      webauthn_setup: webauthn_client.create(challenge: setup_params[:webauthn_setup][:challenge]),
+      webauthn_setup_challenge: setup_params[:webauthn_setup_challenge],
+      webauthn_setup_challenge_hmac: setup_params[:webauthn_setup_challenge_hmac]
+    ).must_be_nil
+
+    auth_params = app.rodauth.webauthn_login_params
+    app.rodauth.webauthn_login(
+      webauthn_auth: webauthn_client.get(challenge: auth_params[:webauthn_auth][:challenge]),
+      webauthn_auth_challenge: auth_params[:webauthn_auth_challenge],
+      webauthn_auth_challenge_hmac: auth_params[:webauthn_auth_challenge_hmac]
+    ).must_equal DB[:accounts].get(:id)
+
+    proc do
+      app.rodauth.webauthn_login_params(login: 'bar@example.com')
+    end.must_raise Rodauth::InternalRequestError
+  end
 end
 end


### PR DESCRIPTION
The Rails app in my current company uses custom authentication, and for a hack week I wanted to add support for passkeys. For this I wanted to try leveraging Rodauth's implementation, by using Rodauth as a library.

This PR extends the internal_request feature with support for WebAuthn actions. Initially, the `*_params` methods were returning webauthn-ruby's credential objects, but that required manually HMAC'ing the challenge. So, I used the same approach as `otp_setup_params` and returned the data as a hash. I like that this encapsulates webauthn-ruby usage within Rodauth, and the caller just deals with plain hashes.

The webauthn feature adds `webauthn_setup_params`, `webauthn_setup`, `webauthn_auth_params`, `webauthn_auth` and `webauthn_remove` methods, the webauthn_login feature adds `webauthn_login_params` and `webauthn_login` methods, while the webauthn_autofill feature makes `webauthn_login_params` not require the login param. The `webauthn_login` method is the only one that returns something (account ID); I was deciding whether I should make `webauthn_setup` return the credential ID, but realized the caller can already retrieve it from the `navigator.credentials.create` result.

I tested this in a sample app, and everything seems to be working correctly 🙂 