### PR TITLE
Throw different field error when WebAuthn credential could not be found in webauthn_autofill

### DIFF
--- a/doc/error_reasons.rdoc
+++ b/doc/error_reasons.rdoc
@@ -38,6 +38,7 @@ Rodauth will call +set_error_reason+ with:
 * :invalid_verify_account_key
 * :invalid_verify_login_change_key
 * :invalid_webauthn_auth_param
+* :invalid_webauthn_id
 * :invalid_webauthn_remove_param
 * :invalid_webauthn_setup_param
 * :invalid_webauthn_sign_count

--- a/doc/webauthn_autofill.rdoc
+++ b/doc/webauthn_autofill.rdoc
@@ -8,6 +8,7 @@ webauthn_login feature.
 
 webauthn_autofill_js :: The javascript code to execute on the login page to enable autofill UI.
 webauthn_autofill_js_route :: The route to the webauthn autofill javascript file.
+webauthn_invalid_webauthn_id_message :: The error message to show when provided WebAuthn ID wasn't found in the database.
 
 == Auth Methods
 

--- a/lib/rodauth/features/webauthn_autofill.rb
+++ b/lib/rodauth/features/webauthn_autofill.rb
@@ -6,6 +6,8 @@ module Rodauth
 
     auth_value_method :webauthn_autofill_js, File.binread(File.expand_path('../../../../javascript/webauthn_autofill.js', __FILE__)).freeze
 
+    translatable_method :webauthn_invalid_webauthn_id_message, "no webauthn key with given id found"
+
     route(:webauthn_autofill_js) do |r|
       before_webauthn_autofill_js_route
       r.get do
@@ -47,7 +49,11 @@ module Rodauth
         .where(webauthn_keys_webauthn_id_column => credential_id)
         .get(webauthn_keys_account_id_column)
 
-      @account = account_ds(account_id).first if account_id
+      unless account_id
+        throw_error_reason(:invalid_webauthn_id, invalid_field_error_status, webauthn_auth_param, webauthn_invalid_webauthn_id_message)
+      end
+
+      @account = account_ds(account_id).first
     end
 
     def webauthn_login_options?

--- a/spec/webauthn_autofill_spec.rb
+++ b/spec/webauthn_autofill_spec.rb
@@ -126,6 +126,11 @@ describe 'Rodauth webauthn_autofill feature' do
     res = json_request('/webauthn-login', :webauthn_auth=>webauthn_client.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
     res.must_equal [200, {'success'=>'You have been logged in'}]
     json_request.must_equal [200, ['webauthn']]
+
+    json_logout
+    DB[:account_webauthn_keys].delete
+    res = json_request('/webauthn-login', :webauthn_auth=>webauthn_client.get(challenge: auth_json['challenge']), :webauthn_auth_challenge=>challenge, :webauthn_auth_challenge_hmac=>challenge_hmac)
+    res.must_equal [422, {"field-error"=>["webauthn_auth", "no webauthn key with given id found"],"error"=>"There was an error authenticating via WebAuthn", "reason"=>"invalid_webauthn_id"}]
   end
 end
 end


### PR DESCRIPTION
When using the WebAuthn autofill UI, the `/webauthn-login` route will receive the selected credential without the login param. It's possible the credential was deleted from the database, this will currently fall through to a "no matching login" field error, which isn't accurate because we're not matching by login here.

To improve this, throw a dedicated field error in this case. It won't be visible in HTML, but it helps make the failure clear for JSON and internal requests. I noticed this when I was working on internal request support for WebAuthn, where the current error message was misleading.
