### PR TITLE
Mention that webauthn_autofill allows WebAuthn login without an email

### DIFF
--- a/doc/webauthn_autofill.rdoc
+++ b/doc/webauthn_autofill.rdoc
@@ -4,6 +4,10 @@ The webauthn_autofill feature enables autofill UI (aka "conditional mediation")
 for WebAuthn credentials, logging the user in on selection. It depends on the
 webauthn_login feature.
 
+This feature allows generating WebAuthn credential options and submitting a
+WebAuthn login request without providing a login, which can be used
+independently from the autofill UI.
+
 == Auth Value Methods
 
 webauthn_autofill_js :: The javascript code to execute on the login page to enable autofill UI.


### PR DESCRIPTION
Generating WebAuthn authentication options without the account's credentials whitelisted is a WebAuthn feature that's not tied to the autofill UI, as I recently learned, it just requires discoverable credentials.

This allows the developer to provide a button for logging in via a passkey, which should have wider browser support compared to conditional mediation. I thought it's useful to mention that in the documentation.
