### PR TITLE
Make clearing session work in internal requests

### DIFF
--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -50,6 +50,10 @@ module Rodauth
       @params[k]
     end
 
+    def clear_session
+      @session.clear
+    end
+
     def set_error_flash(message)
       @flash = message
       _handle_internal_request_error

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -855,7 +855,7 @@ describe 'Rodauth' do
   end
 
   {
-    'should allow different configuerations for internal requests'=>true,
+    'should allow different configurations for internal requests'=>true,
     'should allow use of internal_request? to determine whether this is an internal request'=>false
   }.each do  |desc, use_internal_request_predicate|
     it desc do
@@ -1215,6 +1215,23 @@ describe 'Rodauth' do
         obj
       end
     end.must_raise Rodauth::InternalRequestError
+  end
+
+  it "should be able to clear the session during an internal request" do
+    rodauth do
+      enable :logout, :internal_request
+    end
+    roda do |r|
+      r.rodauth
+      view :content=>""
+    end
+
+    id = DB[:accounts].get(:id)
+
+    app.rodauth.internal_request_eval(:account_id=>id) do
+      logout
+      logged_in?
+    end.must_be_nil
   end
 
   it "should support internal_request_block when handling internal requests" do


### PR DESCRIPTION
When using Roda sessions plugin, the `clear_session` method is called on the Roda object. Similarly, when using rodauth-rails, the `reset_session` method is called on the Rails controller instance. During an internal request, neither of these will actually clear the session, as there the session hash is stored in an instance variable on the Rodauth object.

We fix this by directly clearing the session hash when in an internal request. This makes `internal_request_eval` usage more reliable.
