### PR TITLE
Add guide for rendering confirmation view

### DIFF
--- a/doc/guides/registration_field.rdoc
+++ b/doc/guides/registration_field.rdoc
@@ -10,7 +10,7 @@ or their company's name.
 Let's assume you wanted to wanted to store the additional field(s) directly on
 the +accounts+ table:
 
-  atler_table :accounts do
+  alter_table :accounts do
     add_column :name, String
   end
 

--- a/doc/guides/render_confirmation.rdoc
+++ b/doc/guides/render_confirmation.rdoc
@@ -1,0 +1,17 @@
+= Render confirmation view
+
+Most Rodauth actions redirect and display a flash notice after they're succesfully performed. However, in some cases you may wish to render a view confirming that the action was succesful, for nicer user experience.
+
+For example, when the user creates an account, you might render a page with a call to action to verify their account. Assuming you've created an +account_created+ view template alongside your other Rodauth templates, you can configure the following:
+
+  after_create_account do
+    # render "account_created" view template with page title of "Account created!"
+    return_response view("account_created", "Account created!")
+  end
+
+Similarly, when the user has requested a password reset, you can render a page telling them to check their email:
+
+  after_reset_password_request do
+    # render "password_reset_sent" view template with page title of "Password sent!"
+    return_response view("password_reset_sent", "Password sent!")
+  end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -78,6 +78,7 @@
   <li><a href="rdoc/files/doc/guides/query_params_rdoc.html">Pass query parameters to auth URLs</a></li>
   <li><a href="rdoc/files/doc/guides/redirects_rdoc.html">Change redirect destination</a></li>
   <li><a href="rdoc/files/doc/guides/registration_field_rdoc.html">Add field during account creation</a></li>
+  <li><a href="rdoc/files/doc/guides/render_confirmation_rdoc.html">Render confirmation view</a></li>
   <li><a href="rdoc/files/doc/guides/require_mfa_rdoc.html">Require multifactor authentication after login</a></li>
   <li><a href="rdoc/files/doc/guides/reset_password_autologin_rdoc.html">Autologin after password reset</a></li>
   <li><a href="rdoc/files/doc/guides/share_configuration_rdoc.html">Share configuration via inheritance</a></li>


### PR DESCRIPTION
*Follow-up on https://github.com/jeremyevans/rodauth/discussions/360*

This is a useful technique for rendering views after successful actions, while avoiding having to define routes for those pages, which would make them accessible outside of those actions.
