### PR TITLE
Fix code tag in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1323,7 +1323,7 @@ application to call Rodauth methods.
 
 If you're using the remember feature with +extend_remember_deadline?+ set to
 true, you'll want to load roda's middleware plugin with
-+forward_response_headers: true+ option, so that +Set-Cookie+ header changes
+<tt>forward_response_headers: true</tt> option, so that +Set-Cookie+ header changes
 from the +load_memory+ call in the route block are propagated when the request
 is forwarded to the main app.
 


### PR DESCRIPTION
The `+` symbols are being rendered literally, so probably because of the space we need to use the `<tt>` tag.
