### PR TITLE
respond configuration method

### DIFF
--- a/doc/change_login.rdoc
+++ b/doc/change_login.rdoc
@@ -22,3 +22,4 @@ before_change_login :: Run arbitrary code before changing a login.
 before_change_login_route :: Run arbitrary code before handling a change login route.
 change_login(login) :: Change the users login to the given login, or return nil/false if the login cannot be changed to the given login.
 change_login_view :: The HTML to use for the change login form.
+change_login_response :: Change the logic which sets up the response to a successful login change.

--- a/doc/change_password.rdoc
+++ b/doc/change_password.rdoc
@@ -23,3 +23,4 @@ after_change_password :: Run arbitrary code after successful password change.
 before_change_password :: Run arbitrary code before changing the password for an account.
 before_change_password_route :: Run arbitrary code before handling a change password route.
 change_password_view :: The HTML to use for the change password form.
+change_password_response :: Change the logic which sets up the response to a successful password change.

--- a/doc/close_account.rdoc
+++ b/doc/close_account.rdoc
@@ -23,3 +23,4 @@ before_close_account_route :: Run arbitrary code before handling a close account
 close_account :: Close the account, by default setting the account status to closed.
 close_account_view :: The HTML to use for the close account form.
 delete_account :: If +delete_account_on_close?+ is true, delete the account when closing it.
+close_account_response :: Change the logic which sets up the response to successfully closing an account.

--- a/doc/confirm_password.rdoc
+++ b/doc/confirm_password.rdoc
@@ -29,3 +29,4 @@ before_confirm_password :: Run arbitrary code before setting that the password h
 before_confirm_password_route :: Run arbitrary code before handling the password confirmation route.
 confirm_password :: Update the session to reflect the password has been confirmed.
 confirm_password_view :: The HTML to use for the confirm password form.
+confirm_password_response :: Change the logic which sets up the response to a successful password confirmation.

--- a/doc/create_account.rdoc
+++ b/doc/create_account.rdoc
@@ -21,6 +21,7 @@ before_create_account_route :: Run arbitrary code before handling a create accou
 create_account_autologin? :: Whether to autologin the user upon successful account creation, true by default unless verifying accounts.
 create_account_link_text :: The text to use for a link to the create account form.
 create_account_view :: The HTML to use for the create account form.
+create_account_response :: Change the logic which sets up the response to successfully creating an account.
 new_account(login) :: Instantiate a new account hash for the given login, without saving it.
 save_account :: Insert the account into the database, or return nil/false if that was not successful.
 set_new_account_password :: Set the password for a new account if +account_password_hash_column+ is set, without saving.

--- a/doc/lockout.rdoc
+++ b/doc/lockout.rdoc
@@ -46,14 +46,14 @@ unlock_account_skip_resend_email_within :: The number of seconds before sending 
 
 == Auth Methods
 
-account_from_unlock_key(key) :: Retrieve the account using the given verify account key, or return nil if no account matches. 
+account_from_unlock_key(key) :: Retrieve the account using the given verify account key, or return nil if no account matches.
 after_account_lockout :: Run arbitrary code after an account has been locked out.
 after_unlock_account :: Run arbitrary code after a successful account unlock.
 after_unlock_account_request :: Run arbitrary code after a successful account unlock request.
 before_unlock_account :: Run arbitrary code before unlocking an account.
 before_unlock_account_request :: Run arbitrary code before sending an account unlock email.
 before_unlock_account_request_route :: Run arbitrary code before handling an account unlock request route.
-before_unlock_account_route :: Run arbitrary code before handling an unlock account route. 
+before_unlock_account_route :: Run arbitrary code before handling an unlock account route.
 clear_invalid_login_attempts :: Clear any stored login failures or lockouts for the current account.
 create_unlock_account_email :: A Mail::Message for the account unlock email to send.
 generate_unlock_account_key :: A random string to use for a new unlock account key.
@@ -69,3 +69,4 @@ unlock_account_email_link :: The link to the unlock account form to include in t
 unlock_account_key :: The unlock account key for the current account.
 unlock_account_request_view :: The HTML to use for the unlock account request form.
 unlock_account_view :: The HTML to use for the unlock account form.
+unlock_account_response :: Change the logic which sets up the response to successfulll locking an account.

--- a/doc/login.rdoc
+++ b/doc/login.rdoc
@@ -34,5 +34,6 @@ use_multi_phase_login? :: Whether to ask for login first, and only ask for passw
 
 before_login_route :: Run arbitrary code before handling a login route.
 login_view :: The HTML to use for the login form.
+login_response :: Change the logic which sets up the response to a successful login.
 login_return_to_requested_location_path :: If +login_return_to_requested_location?+ is true, the path to use as the requested location.  By default, uses the full path of the request for GET requests, and is nil for non-GET requests (in which case the default +login_redirect+ will be used).
 multi_phase_login_view :: The HTML to use for the login form after login has been entered when using multi phase login.

--- a/doc/logout.rdoc
+++ b/doc/logout.rdoc
@@ -19,3 +19,4 @@ before_logout :: Run arbitrary code before logout.
 before_logout_route :: Run arbitrary code before handling a logout route.
 logout :: Log the user out, by default clearing the session.
 logout_view :: The HTML to use for the logout form.
+logout_response :: Change the logic which sets up the response to a successful logout.

--- a/doc/otp.rdoc
+++ b/doc/otp.rdoc
@@ -72,6 +72,7 @@ otp_add_key(secret) :: Add an OTP key for the current account with the given sec
 otp_auth_view :: The HTML to use for the OTP authentication form.
 otp_available? :: Whether OTP authentication is ready for use.
 otp_disable_view :: The HTML to use for the OTP disable form.
+otp_disable_response :: Change the logic which sets up the response to successfully disabling OTP.
 otp_exists? :: Whether the current account has setup OTP.
 otp_key :: The stored OTP secret for the account.
 otp_last_use :: The last time OTP authentication was successful for the account.
@@ -84,6 +85,7 @@ otp_record_authentication_failure :: Record an OTP authentication failure.
 otp_remove :: Removes all stored OTP data for the current account.
 otp_remove_auth_failures :: Removes OTP authentication failures for the current account, used after successful multifactor authentication.
 otp_setup_view :: The HTML to use for the form to setup OTP authentication.
+otp_setup_response :: Change the logic which sets up the response to successfully setting up OTP.
 otp_tmp_key(secret) :: Set the secret to use for the temporary OTP key, during OTP setup.
 otp_update_last_use :: Update the last time OTP authentication was successful for the account.  Return true if the authentication should be allowed, or false if it should not be allowed because the last authentication was too recent and indicates the possible reuse of a TOTP authentication code.
 otp_valid_code_for_old_secret :: Called when valid OTP authentication is performed using hmac_old_secret.  This indicates the OTP needs to be rotated before support for the previous hmac secret value is removed.  You can use this to track users who need their OTP rotated, and take appropriate action.

--- a/doc/remember.rdoc
+++ b/doc/remember.rdoc
@@ -75,4 +75,5 @@ remembered_session_id :: The session_id which is validly remembered, if any.
 remember_key_value :: The current value of the remember key/token.
 remember_login :: Set the cookie containing the remember token, so that future sessions will be autologged in.
 remember_view :: The HTML to use for the change remember settings form.
+remember_response :: Change the logic which sets up the response to successfully changing remember settings.
 remove_remember_key(id_value=account_id) :: Delete the related remember key from the database.

--- a/doc/reset_password.rdoc
+++ b/doc/reset_password.rdoc
@@ -62,3 +62,5 @@ reset_password_request_view :: The HTML to use for the reset password request fo
 reset_password_view :: The HTML to use for the reset password form.
 send_reset_password_email :: Send the reset password request email.
 set_reset_password_email_last_sent :: Set the last time a reset password request email is sent.
+reset_password_email_sent_response :: Change the logic which sets up the response to successfully sending a password reset email.
+reset_password_response :: Change the logic which sets up the response to successfully resetting password.

--- a/doc/sms_codes.rdoc
+++ b/doc/sms_codes.rdoc
@@ -110,10 +110,12 @@ sms_code_issued_at :: The timestamp the current SMS code was issued at.
 sms_code_match?(code) :: Whether there is an active SMS authentication code for the current account and the given code matches it.
 sms_confirm_message(code) :: The SMS message to use for the given confirmation code.
 sms_confirm_view :: The HTML to use for the form to authenticate via SMS code.
+sms_confirm_response :: Change the logic which sets up the response to successfully confirming the SMS code.
 sms_confirmation_match?(code) :: Whether there is an active SMS confirmation code for the current account and the given code matches it.
 sms_current_auth? :: Whether there is a active SMS authentication code for the current account.
 sms_disable :: Action to take to disable SMS authentication for the account.
 sms_disable_view :: The HTML to use for the form to disable SMS authentication.
+sms_disable_response :: Change the logic which sets up the response to successfully disabling SMS authentication.
 sms_failures :: The number of SMS authentication failures since the last successfully SMS authentication for this account.
 sms_locked_out? :: Whether SMS authentication has been locked out for the current account.
 sms_needs_confirmation? :: Whether SMS authentication has been setup but not confirmed for the current account.

--- a/doc/two_factor_base.rdoc
+++ b/doc/two_factor_base.rdoc
@@ -66,3 +66,4 @@ two_factor_remove_links :: An array of entries for remove links to show on the m
 two_factor_remove_session :: What actions to take to remove multifactor authentication status from the session, called when disabling multifactor authentication when authenticated using the factor being removed.
 two_factor_setup_links :: An array of entries for setup links to show on the multifactor manage page.  Each entry is an array of three elements, sort order (integer), link href, and link text.
 two_factor_update_session(type) :: How to update the session to reflect a successful multifactor authentication.
+two_factor_disable_response :: Change the logic which sets up the response to successfully multifactor authentication.

--- a/doc/verify_account.rdoc
+++ b/doc/verify_account.rdoc
@@ -63,3 +63,4 @@ verify_account_email_link :: The link to the verify account form in the verify a
 verify_account_key_insert_hash :: The hash to insert into the +verify_account_table+.
 verify_account_key_value :: The value of the verify account key.
 verify_account_view :: The HTML to use for the verify account form.
+verify_account_response :: Change the logic which sets up the response to a successful account verification.

--- a/doc/verify_login_change.rdoc
+++ b/doc/verify_login_change.rdoc
@@ -56,3 +56,4 @@ verify_login_change_key_value :: The value of the verify login change key.
 verify_login_change_new_login :: The new login to use when the login change is verified.
 verify_login_change_old_login :: The old login to display in the verify login change email.
 verify_login_change_view :: The HTML to use for the verify login change form.
+verify_login_change_response :: Change the logic which sets up the response to a successful login change verificatin.

--- a/doc/webauthn.rdoc
+++ b/doc/webauthn.rdoc
@@ -110,7 +110,9 @@ webauthn_credential_options_for_get :: WebAuthn credential options to provide to
 webauthn_key_insert_hash(webauthn_credential) :: The hash to insert into the +webauthn_keys_table+.
 webauthn_remove_authenticated_session :: Remove the authenticated WebAuthn ID, used when removing the WebAuthn credential with the ID after authenticating with it.
 webauthn_remove_view :: The HTML to use for the page for removing an existing WebAuthn authenticator.
+webauthn_remove_response :: Change the logic which sets up the response to successfully removing an existing WebAuthn authenticator.
 webauthn_setup_js_path :: The path to the WebAuthn registration javascript.
 webauthn_setup_view :: The HTML to use for the page for registering a new WebAuthn authenticator.
+webauthn_setup_response :: Change the logic which sets up the response to successfully registering a new WebAuthn authenticator.
 webauthn_update_session(webauthn_id) :: Set the authenticated WebAuthn ID after authenticating via WebAuthn.
 webauthn_user_name :: The user name to use when registering a new WebAuthn credential, the user's email by default.

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -214,6 +214,17 @@ module Rodauth
       auth_methods meth
     end
 
+    def response(name=feature_name)
+      meth = :"#{name}_response"
+      notice_flash_meth = :"#{name}_notice_flash"
+      redirect_meth = :"#{name}_redirect"
+      define_method(meth) do
+        set_notice_flash send(notice_flash_meth)
+        redirect send(redirect_meth)
+      end
+      auth_methods meth
+    end
+
     def loaded_templates(v)
       define_method(:loaded_templates) do
         super().concat(v)

--- a/lib/rodauth/features/change_login.rb
+++ b/lib/rodauth/features/change_login.rb
@@ -14,6 +14,7 @@ module Rodauth
     additional_form_tags
     button 'Change Login'
     redirect
+    response
 
     auth_value_methods :change_login_requires_password?
 
@@ -51,9 +52,8 @@ module Rodauth
             end
 
             after_change_login
-            set_notice_flash change_login_notice_flash
-            redirect change_login_redirect
           end
+          change_login_response
         end
 
         set_error_flash change_login_error_flash

--- a/lib/rodauth/features/change_password.rb
+++ b/lib/rodauth/features/change_password.rb
@@ -13,6 +13,7 @@ module Rodauth
     additional_form_tags
     button 'Change Password'
     redirect
+    response
 
     translatable_method :new_password_label, 'New Password'
     auth_value_method :new_password_param, 'new-password'
@@ -56,8 +57,7 @@ module Rodauth
             set_password(password)
             after_change_password
           end
-          set_notice_flash change_password_notice_flash
-          redirect change_password_redirect
+          change_password_response
         end
 
         set_error_flash change_password_error_flash

--- a/lib/rodauth/features/close_account.rb
+++ b/lib/rodauth/features/close_account.rb
@@ -11,6 +11,7 @@ module Rodauth
     after
     before
     redirect
+    response
 
     auth_value_method :account_closed_status_value, 3
 
@@ -50,8 +51,7 @@ module Rodauth
           end
           clear_session
 
-          set_notice_flash close_account_notice_flash
-          redirect close_account_redirect
+          close_account_response
         end
 
         set_error_flash close_account_error_flash

--- a/lib/rodauth/features/confirm_password.rb
+++ b/lib/rodauth/features/confirm_password.rb
@@ -11,6 +11,7 @@ module Rodauth
     button 'Confirm Password'
     before
     after
+    response
     redirect(:password_authentication_required){confirm_password_path}
 
     session_key :confirm_password_redirect_session_key, :confirm_password_redirect
@@ -37,8 +38,7 @@ module Rodauth
             confirm_password
             after_confirm_password
           end
-          set_notice_flash confirm_password_notice_flash
-          redirect confirm_password_redirect
+          confirm_password_response
         else
           set_response_error_reason_status(:invalid_password, invalid_password_error_status)
           set_field_error(password_param, invalid_password_message)

--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -13,6 +13,7 @@ module Rodauth
     button 'Create Account'
     additional_form_tags
     redirect
+    response
 
     auth_value_method :create_account_autologin?, true
     translatable_method :create_account_link_text, "Create a New Account"
@@ -79,8 +80,7 @@ module Rodauth
             if create_account_autologin?
               autologin_session('create_account')
             end
-            set_notice_flash create_account_notice_flash
-            redirect create_account_redirect
+            create_account_response
           end
         end
 

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -23,10 +23,12 @@ module Rodauth
     notice_flash "Your account has been unlocked", 'unlock_account'
     notice_flash "An email has been sent to you with a link to unlock your account", 'unlock_account_request'
     redirect :unlock_account
+    response :unlock_account
     redirect(:unlock_account_request){default_post_email_redirect}
     redirect(:unlock_account_email_recently_sent){default_post_email_redirect}
     email :unlock_account, 'Unlock Account'
-      
+
+
     auth_value_method :unlock_account_autologin?, true
     auth_value_method :max_invalid_logins, 100
     auth_value_method :account_login_failures_table, :account_login_failures
@@ -134,8 +136,7 @@ module Rodauth
           end
 
           remove_session_value(unlock_account_session_key)
-          set_notice_flash unlock_account_notice_flash
-          redirect unlock_account_redirect
+          unlock_account_response
         else
           set_response_error_reason_status(:invalid_password, invalid_password_error_status)
           set_field_error(password_param, invalid_password_message)

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -23,6 +23,7 @@ module Rodauth
     auth_cached_method :login_form_footer
 
     auth_value_methods :login_return_to_requested_location_path
+    auth_methods :login_response
 
     auth_private_methods :login_form_footer_links
 
@@ -77,15 +78,22 @@ module Rodauth
     end
 
     attr_reader :login_form_header
+    attr_reader :saved_login_redirect
+    private :saved_login_redirect
+
 
     def login(auth_type)
-      saved_login_redirect = remove_session_value(login_redirect_session_key)
+      @saved_login_redirect = remove_session_value(login_redirect_session_key)
       transaction do
         before_login
         login_session(auth_type)
         yield if block_given?
         after_login
       end
+      login_response
+    end
+
+    def login_response
       set_notice_flash login_notice_flash
       redirect(saved_login_redirect || login_redirect)
     end

--- a/lib/rodauth/features/logout.rb
+++ b/lib/rodauth/features/logout.rb
@@ -10,6 +10,7 @@ module Rodauth
     after
     button 'Logout'
     redirect{require_login_redirect}
+    response
 
     auth_methods :logout
 
@@ -26,8 +27,7 @@ module Rodauth
           logout
           after_logout
         end
-        set_notice_flash logout_notice_flash
-        redirect logout_redirect
+        logout_response
       end
     end
 

--- a/lib/rodauth/features/otp.rb
+++ b/lib/rodauth/features/otp.rb
@@ -35,6 +35,8 @@ module Rodauth
     redirect :otp_disable
     redirect :otp_already_setup
     redirect :otp_setup
+    response :otp_disable
+    response :otp_setup
     redirect(:otp_lockout){two_factor_auth_required_redirect}
 
     loaded_templates %w'otp-disable otp-auth otp-setup otp-auth-code-field password-field'
@@ -182,8 +184,7 @@ module Rodauth
             end
             after_otp_setup
           end
-          set_notice_flash otp_setup_notice_flash
-          redirect otp_setup_redirect
+          otp_setup_response
         end
 
         set_error_flash otp_setup_error_flash
@@ -210,8 +211,7 @@ module Rodauth
             end
             after_otp_disable
           end
-          set_notice_flash otp_disable_notice_flash
-          redirect otp_disable_redirect
+          otp_disable_response
         end
 
         set_response_error_reason_status(:invalid_password, invalid_password_error_status)
@@ -247,7 +247,7 @@ module Rodauth
     def otp_exists?
       !otp_key.nil?
     end
-    
+
     def otp_valid_code?(ot_pass)
       if _otp_valid_code?(ot_pass, otp)
         true

--- a/lib/rodauth/features/remember.rb
+++ b/lib/rodauth/features/remember.rb
@@ -13,6 +13,7 @@ module Rodauth
     after
     after 'load_memory'
     redirect
+    response
 
     auth_value_method :raw_remember_token_deadline, nil
     auth_value_method :remember_cookie_options, {}.freeze
@@ -71,15 +72,14 @@ module Rodauth
             when remember_remember_param_value
               remember_login
             when remember_forget_param_value
-              forget_login 
+              forget_login
             when remember_disable_param_value
-              disable_remember_login 
+              disable_remember_login
             end
             after_remember
           end
 
-          set_notice_flash remember_notice_flash
-          redirect remember_redirect
+          remember_response
         else
           set_response_error_reason_status(:invalid_remember_param, invalid_field_error_status)
           set_error_flash remember_error_flash

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -24,8 +24,10 @@ module Rodauth
     redirect
     redirect(:reset_password_email_sent){default_post_email_redirect}
     redirect(:reset_password_email_recently_sent){default_post_email_redirect}
+    response
+    response :reset_password_email_sent
     email :reset_password, 'Reset Password'
-    
+
     auth_value_method :reset_password_deadline_column, :deadline
     auth_value_method :reset_password_deadline_interval, {:days=>1}.freeze
     auth_value_method :reset_password_key_param, 'key'
@@ -88,8 +90,7 @@ module Rodauth
             after_reset_password_request
           end
 
-          set_notice_flash reset_password_email_sent_notice_flash
-          redirect reset_password_email_sent_redirect
+          reset_password_email_sent_response
         end
 
         set_error_flash reset_password_request_error_flash
@@ -154,8 +155,7 @@ module Rodauth
           end
 
           remove_session_value(reset_password_session_key)
-          set_notice_flash reset_password_notice_flash
-          redirect reset_password_redirect
+          reset_password_response
         end
 
         set_error_flash reset_password_error_flash

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -54,6 +54,8 @@ module Rodauth
     redirect(:sms_needs_setup){sms_setup_path}
     redirect(:sms_request){sms_request_path}
     redirect(:sms_lockout){two_factor_auth_required_redirect}
+    response :sms_confirm
+    response :sms_disable
 
     loaded_templates %w'sms-auth sms-confirm sms-disable sms-request sms-setup sms-code-field password-field'
     view 'sms-auth', 'Authenticate via SMS Code', 'sms_auth'
@@ -136,7 +138,7 @@ module Rodauth
           sms_send_auth_code
           after_sms_request
         end
-        
+
         set_notice_flash sms_request_notice_flash
         redirect sms_auth_redirect
       end
@@ -256,8 +258,7 @@ module Rodauth
             end
           end
 
-          set_notice_flash sms_confirm_notice_flash
-          redirect sms_confirm_redirect
+          sms_confirm_response
         end
 
         sms_confirm_failure
@@ -287,8 +288,7 @@ module Rodauth
             end
             after_sms_disable
           end
-          set_notice_flash sms_disable_notice_flash
-          redirect sms_disable_redirect
+          sms_disable_response
         end
 
         set_response_error_reason_status(:invalid_password, invalid_password_error_status)

--- a/lib/rodauth/features/two_factor_base.rb
+++ b/lib/rodauth/features/two_factor_base.rb
@@ -23,6 +23,8 @@ module Rodauth
     redirect(:two_factor_need_setup){two_factor_manage_path}
     redirect(:two_factor_auth_required){two_factor_auth_path}
 
+    response :two_factor_disable
+
     notice_flash "You have been multifactor authenticated", "two_factor_auth"
     notice_flash "All multifactor authentication methods have been disabled", "two_factor_disable"
 
@@ -106,8 +108,7 @@ module Rodauth
             _two_factor_remove_all_from_session
             after_two_factor_disable
           end
-          set_notice_flash two_factor_disable_notice_flash
-          redirect two_factor_disable_redirect
+          two_factor_disable_response
         end
 
         set_response_error_reason_status(:invalid_password, invalid_password_error_status)

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -24,6 +24,7 @@ module Rodauth
     button 'Verify Account'
     button 'Send Verification Email Again', 'verify_account_resend'
     redirect
+    response
     redirect(:verify_account_email_sent){default_post_email_redirect}
     redirect(:verify_account_email_recently_sent){default_post_email_redirect}
     email :verify_account, 'Verify Account'
@@ -154,8 +155,7 @@ module Rodauth
           end
 
           remove_session_value(verify_account_session_key)
-          set_notice_flash verify_account_notice_flash
-          redirect verify_account_redirect
+          verify_account_response
         end
 
         set_error_flash verify_account_error_flash

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -18,6 +18,7 @@ module Rodauth
     before 'verify_login_change_email'
     button 'Verify Login Change'
     redirect
+    response
     redirect(:verify_login_change_duplicate_account){require_login_redirect}
 
     auth_value_method :verify_login_change_autologin?, false
@@ -98,8 +99,7 @@ module Rodauth
         end
 
         remove_session_value(verify_login_change_session_key)
-        set_notice_flash verify_login_change_notice_flash
-        redirect verify_login_change_redirect
+        verify_login_change_response
       end
     end
 

--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -30,6 +30,8 @@ module Rodauth
 
     redirect :webauthn_setup
     redirect :webauthn_remove
+    response :webauthn_setup
+    response :webauthn_remove
 
     notice_flash "WebAuthn authentication is now setup", 'webauthn_setup'
     notice_flash "WebAuthn authenticator has been removed", 'webauthn_remove'
@@ -194,8 +196,7 @@ module Rodauth
             throw_error_reason(:duplicate_webauthn_id, invalid_field_error_status, webauthn_setup_param, webauthn_duplicate_webauthn_id_message)
           end
 
-          set_notice_flash webauthn_setup_notice_flash
-          redirect webauthn_setup_redirect
+          webauthn_setup_response
         end
 
         set_error_flash webauthn_setup_error_flash
@@ -235,8 +236,7 @@ module Rodauth
             after_webauthn_remove
           end
 
-          set_notice_flash webauthn_remove_notice_flash
-          redirect webauthn_remove_redirect
+          webauthn_remove_response
         end
 
         set_error_flash webauthn_remove_error_flash


### PR DESCRIPTION
most/all success responses to POST actions involve setting a flash message and a redirect response. This abstract it by having a method which does both, and can be overridden if the user wants to do something else, like rendering a success page, run some js, smth else.

from https://github.com/jeremyevans/rodauth/discussions/368