### PR TITLE
Support custom primary key in accounts table on MySQL

### DIFF
--- a/lib/rodauth/features/create_account.rb
+++ b/lib/rodauth/features/create_account.rb
@@ -106,7 +106,7 @@ module Rodauth
       end
 
       if id
-        account[account_id_column] = id
+        account[account_id_column] ||= id
       end
 
       id && !raised


### PR DESCRIPTION
Following on https://github.com/janko/rodauth-rails/discussions/239, if one wants to use UUID primary keys on MySQL, one possibility is using a string column and generating UUIDs in Ruby.

```rb
create_table :accounts do
  String :id, primary_key: true
  # ...
end
```
```rb
before_create_account do
  account[:id] = SecureRandom.uuid
end
```

However, Sequel's `#insert` appears to return `0` when the primary key is something other than an autoincrementing integer on MySQL. This causes Rodauth's `#save_account` to overwrite the generated UUID with `0` on the account hash, causing problems down the line in things like account verification.

My idea was to just modify `#save_account` to set the `:id` if it wasn't already set. My only blocker is how to write tests for this. On Postgres, the primary key value is always returned because of the `RETURNING` clause. I was thinking of piggy backing on the `$RODAUTH_SPEC_UUID` path, but that's currently Postgres-only.
