### PR TITLE
Update `documentation.erb` to add external guide

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -103,6 +103,12 @@
   <li><a href="https://gitlab.com/honeyryderchuck/rodauth-select-account">rodauth-select-account</a>: Support logging into multiple accounts in the same session.</li>
 </ul>
 
+<h2 id="external-guides">External Guides</h2>
+
+<ul>
+  <li><a href="https://documenter.getpostman.com/view/26686011/2s9YC7SWn9">Documentation of Rodauth routes for JSON requests</a></li>
+</ul>
+
 <h2><a href="rdoc/files/CHANGELOG.html">Change Log</a></h2>
 
 <h2 id="release-notes">Release Notes</h2>


### PR DESCRIPTION
This external guide is a documentation of Rodauth Routes for JSON requests.