### PR TITLE
Return error response instead of 404 when token is missing

### DIFF
--- a/lib/rodauth/features/email_auth.rb
+++ b/lib/rodauth/features/email_auth.rb
@@ -77,14 +77,12 @@ module Rodauth
           redirect(r.path)
         end
 
-        if key = session[email_auth_session_key]
-          if account_from_email_auth_key(key)
-            email_auth_view
-          else
-            remove_session_value(email_auth_session_key)
-            set_redirect_error_flash no_matching_email_auth_key_error_flash
-            redirect require_login_redirect
-          end
+        if (key = session[email_auth_session_key]) && account_from_email_auth_key(key)
+          email_auth_view
+        else
+          remove_session_value(email_auth_session_key)
+          set_redirect_error_flash no_matching_email_auth_key_error_flash
+          redirect require_login_redirect
         end
       end
 

--- a/lib/rodauth/features/lockout.rb
+++ b/lib/rodauth/features/lockout.rb
@@ -104,14 +104,12 @@ module Rodauth
           redirect(r.path)
         end
 
-        if key = session[unlock_account_session_key]
-          if account_from_unlock_key(key)
-            unlock_account_view
-          else
-            remove_session_value(unlock_account_session_key)
-            set_redirect_error_flash no_matching_unlock_account_key_error_flash
-            redirect require_login_redirect
-          end
+        if (key = session[unlock_account_session_key]) && account_from_unlock_key(key)
+          unlock_account_view
+        else
+          remove_session_value(unlock_account_session_key)
+          set_redirect_error_flash no_matching_unlock_account_key_error_flash
+          redirect require_login_redirect
         end
       end
 

--- a/lib/rodauth/features/reset_password.rb
+++ b/lib/rodauth/features/reset_password.rb
@@ -109,14 +109,12 @@ module Rodauth
           redirect(r.path)
         end
 
-        if key = session[reset_password_session_key]
-          if account_from_reset_password_key(key)
-            reset_password_view
-          else
-            remove_session_value(reset_password_session_key)
-            set_redirect_error_flash no_matching_reset_password_key_error_flash
-            redirect require_login_redirect
-          end
+        if (key = session[reset_password_session_key]) && account_from_reset_password_key(key)
+          reset_password_view
+        else
+          remove_session_value(reset_password_session_key)
+          set_redirect_error_flash no_matching_reset_password_key_error_flash
+          redirect require_login_redirect
         end
       end
 

--- a/lib/rodauth/features/verify_account.rb
+++ b/lib/rodauth/features/verify_account.rb
@@ -102,14 +102,12 @@ module Rodauth
           redirect(r.path)
         end
 
-        if key = session[verify_account_session_key]
-          if account_from_verify_account_key(key)
-            verify_account_view
-          else
-            remove_session_value(verify_account_session_key)
-            set_redirect_error_flash no_matching_verify_account_key_error_flash
-            redirect require_login_redirect
-          end
+        if (key = session[verify_account_session_key]) && account_from_verify_account_key(key)
+          verify_account_view
+        else
+          remove_session_value(verify_account_session_key)
+          set_redirect_error_flash no_matching_verify_account_key_error_flash
+          redirect require_login_redirect
         end
       end
 

--- a/lib/rodauth/features/verify_login_change.rb
+++ b/lib/rodauth/features/verify_login_change.rb
@@ -62,14 +62,12 @@ module Rodauth
           redirect(r.path)
         end
 
-        if key = session[verify_login_change_session_key]
-          if account_from_verify_login_change_key(key)
-            verify_login_change_view
-          else
-            remove_session_value(verify_login_change_session_key)
-            set_redirect_error_flash no_matching_verify_login_change_key_error_flash
-            redirect require_login_redirect
-          end
+        if (key = session[verify_login_change_session_key]) && account_from_verify_login_change_key(key)
+          verify_login_change_view
+        else
+          remove_session_value(verify_login_change_session_key)
+          set_redirect_error_flash no_matching_verify_login_change_key_error_flash
+          redirect require_login_redirect
         end
       end
 

--- a/spec/email_auth_spec.rb
+++ b/spec/email_auth_spec.rb
@@ -25,7 +25,8 @@ describe 'Rodauth email auth feature' do
     page.current_path.must_equal '/'
     link = email_link(/(\/email-auth\?key=.+)$/)
 
-    proc{visit '/email-auth'}.must_raise RuntimeError
+    visit '/email-auth'
+    page.find('#error_flash').text.must_equal "There was an error logging you in: invalid email authentication key"
 
     visit link[0...-1]
     page.find('#error_flash').text.must_equal "There was an error logging you in: invalid email authentication key"

--- a/spec/lockout_spec.rb
+++ b/spec/lockout_spec.rb
@@ -49,7 +49,8 @@ describe 'Rodauth lockout feature' do
     click_button 'Request Account Unlock'
     email_link(/(\/unlock-account\?key=.+)$/).must_equal link
 
-    proc{visit '/unlock-account'}.must_raise RuntimeError
+    visit '/unlock-account'
+    page.find('#error_flash').text.must_equal "There was an error unlocking your account: invalid or expired unlock account key"
 
     visit link[0...-1]
     page.find('#error_flash').text.must_equal "There was an error unlocking your account: invalid or expired unlock account key"

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -30,7 +30,8 @@ describe 'Rodauth reset_password feature' do
       page.current_path.must_equal '/'
       link = email_link(/(\/reset-password\?key=.+)$/)
 
-      proc{visit '/reset-password'}.must_raise RuntimeError
+      visit '/reset-password'
+      page.find('#error_flash').text.must_equal "There was an error resetting your password: invalid or expired password reset key"
 
       visit link[0...-1]
       page.find('#error_flash').text.must_equal "There was an error resetting your password: invalid or expired password reset key"

--- a/spec/verify_account_spec.rb
+++ b/spec/verify_account_spec.rb
@@ -191,7 +191,8 @@ describe 'Rodauth verify_account feature' do
     click_button 'Send Verification Email Again'
     page.find('#error_flash').text.must_equal 'Unable to resend verify account email'
 
-    proc{visit '/verify-account'}.must_raise RuntimeError
+    visit '/verify-account'
+    page.find('#error_flash').text.must_equal 'There was an error verifying your account: invalid verify account key'
   end
 
   it "should support autologin when verifying accounts" do

--- a/spec/verify_login_change_spec.rb
+++ b/spec/verify_login_change_spec.rb
@@ -32,7 +32,8 @@ describe 'Rodauth verify_login_change feature' do
 
     logout
 
-    proc{visit '/verify-login-change'}.must_raise RuntimeError
+    visit '/verify-login-change'
+    page.find('#error_flash').text.must_equal "There was an error verifying your login change: invalid verify login change key"
 
     visit link
     page.find('#error_flash').text.must_equal "There was an error verifying your login change: invalid verify login change key"


### PR DESCRIPTION
When a page requiring a token is requested without a token, Rodauth currently returns a 404 response. If Rodauth is used as a middleware with `:next_if_not_found` plugin option enabled, this request would be forwarded to the main app. This behavior can be misleading for the developer, because it might communicate that it's not a route handled by Rodauth.

I encountered this when I mistakenly generated a `/reset-password` link instead of `/reset-password-request`, and then being confused by the response, only to realize what happened because I was familiar with Rodauth internals.

I think it's better to instead return an error response that the required token is missing. This makes things clearer to the developer, and also ensures the request doesn't get forwarded to the main app.
