### PR TITLE
Allow retrieving current route name

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -138,6 +138,7 @@ module Rodauth
 
       define_method(handle_meth) do
         request.is send(route_meth) do
+          @route = name
           check_csrf if check_csrf?
           _around_rodauth do
             before_rodauth

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -136,6 +136,7 @@ module Rodauth
 
     attr_reader :scope
     attr_reader :account
+    attr_reader :route
 
     def initialize(scope)
       @scope = scope

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -327,6 +327,26 @@ describe 'Rodauth' do
     ['http://www.example.com/auth/login?a%5B%5D=b&a%5B%5D=c', 'http://www.example.com/auth/login?a[]=b&a[]=c'].must_include page.text
   end
 
+  it "should set current route" do
+    rodauth do
+      enable :login
+      login_additional_form_tags { "<span id=\"current-route\">#{route}</span>" }
+    end
+    roda do |r|
+      r.rodauth
+      r.root { "Current route: #{rodauth.route.inspect}" }
+    end
+
+    visit '/login'
+    page.find("#current-route").text.must_equal "login"
+
+    click_on 'Login'
+    page.find("#current-route").text.must_equal "login"
+
+    visit '/'
+    page.text.must_equal "Current route: nil"
+  end
+
   it "should support disabling routes" do
     rodauth do
       enable :create_account, :internal_request


### PR DESCRIPTION
As discussed in https://github.com/jeremyevans/rodauth/discussions/380, this is useful for generating path or URL for current route with different parameters, while still reusing configured route definitions.

```rb
# locale switcher with query parameter
rodauth.send(:"#{rodauth.route}_path", request.GET.merge("locale" => "br"))
#=> "/create-account?locale=br"

# locale switcher with path prefix, assuming `prefix { "/#{I18n.locale}/auth" }`
I18n.with_locale("br") { rodauth.send(:"#{rodauth.route}_path", request.GET) }
#=> "/br/auth/create-account"
```

This is the minimal functionality needed to support this use case. I was considering also adding `current_path` and `current_url` methods that would utilize this, but thought that might be an overkill for now.