### PR TITLE
Add Ubicloud to applications using Rodauth

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -156,4 +156,5 @@
   <li><a href="https://github.com/jeremyevans/giftsmas">Giftsmas</a> (Gift Tracking)</li>
   <li><a href="https://github.com/jeremyevans/kaeruera">KaeruEra</a> (Exception Tracking)</li>
   <li><a href="https://github.com/enterprise-oss/osso">Osso</a> (SAML to OAuth bridge)</li>
+  <li><a href="https://github.com/ubicloud/ubicloud">Ubicloud</a> (Open, Free, and Portable Cloud)</li>
 </ul>


### PR DESCRIPTION
Judging from https://github.com/ubicloud/ubicloud/pull/952, it seems that they're using Rodauth at an advanced level too.
