### PR TITLE
Handle deleted account when checking whether MFA is setup

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -712,7 +712,7 @@ module Rodauth
     # note that only the salt is returned.
     def get_password_hash
       if account_password_hash_column
-        account![account_password_hash_column]
+        account[account_password_hash_column] if account!
       elsif use_database_authentication_functions?
         db.get(Sequel.function(function_name(:rodauth_get_salt), account ? account_id : session_value))
       else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -475,8 +475,7 @@ class Minitest::HooksSpec
       else
         BCrypt::Password.create('0123456789', :cost=>BCrypt::Engine::MIN_COST)
       end
-      table = ENV['RODAUTH_SEPARATE_SCHEMA'] ? Sequel[:rodauth_test_password][:account_password_hashes] : :account_password_hashes
-      DB[table].insert(:id=>DB[:accounts].insert(:email=>'foo@example.com', :status_id=>2, :ph=>hash), :password_hash=>hash)
+      DB[PASSWORD_HASH_TABLE].insert(:id=>DB[:accounts].insert(:email=>'foo@example.com', :status_id=>2, :ph=>hash), :password_hash=>hash)
       super(&block)
     end
   end


### PR DESCRIPTION
It's possible that an account is signed in but the record gets deleted in the database, especially in development where it's common to clear testing data. When `#uses_two_factor_authentication?` is called, it ends up calling `#has_password?`, which errors if the logged in account record doesn't exist. I thought it would be nice if Rodauth gracefully handled that.

I also made two spec changes on the way: one was to use the `PASSWORD_HASH_TABLE` constant, the other was renaming the spec name to communicate that it's testing all MFA behavior.