### PR TITLE
Allow skipping DB calls on configure when overriding `convert_token_id_to_integer?`

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -429,7 +429,7 @@ module Rodauth
       require 'bcrypt' if require_bcrypt?
       db.extension :date_arithmetic if use_date_arithmetic?
 
-      if convert_token_id_to_integer?.nil? && (db rescue false) && db.table_exists?(accounts_table) && db.schema(accounts_table).find{|col, v| break v[:type] == :integer if col == account_id_column}
+      if method(:convert_token_id_to_integer?).owner == Rodauth::Base && (db rescue false) && db.table_exists?(accounts_table) && db.schema(accounts_table).find{|col, v| break v[:type] == :integer if col == account_id_column}
         self.class.send(:define_method, :convert_token_id_to_integer?){true}
       end
 


### PR DESCRIPTION
In rodauth-rails, I set `convert_token_id_to_integer? true` in the default generated Rodauth configuration, in order to avoid DB queries at boot time when eager loading was turned on in development. This enables rake tasks such as `db:create` to still work, which boot the application without the database existing.

However, this causes tokens to silently stop working if the primary key is later switched to UUIDs. So, I would like a way to set `convert_token_id_to_integer?` to the correct value based on primary key type, but without requiring a DB connection at configure time.

```rb
# use Active Record schema cache to determine primary key type
convert_token_id_to_integer? { Account.columns_hash[account_id_column.to_s].type == :integer }
```

To make this work, I wanted to propose that Rodauth skips calling `convert_token_id_to_integer?` and its schema resolution on configure if it was overridden.
