### PR TITLE
Update require login redirect when login route changes

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -67,8 +67,6 @@ module Rodauth
     translatable_method :unverified_account_message, "unverified account, please verify account before logging in"
     auth_value_method :default_field_attributes, ''
 
-    redirect(:require_login){"#{prefix}/login"}
-
     auth_value_methods(
       :base_url,
       :check_csrf?,
@@ -77,6 +75,7 @@ module Rodauth
       :login_input_type,
       :login_uses_email?,
       :modifications_require_password?,
+      :require_login_redirect,
       :set_deadline_values?,
       :use_date_arithmetic?,
       :use_database_authentication_functions?,
@@ -331,6 +330,10 @@ module Rodauth
       set_error_reason :login_required
       set_redirect_error_flash require_login_error_flash
       redirect require_login_redirect
+    end
+
+    def require_login_redirect
+      "#{prefix}/login"
     end
 
     def set_title(title)

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -138,6 +138,10 @@ module Rodauth
       multi_phase_login_forms.sort.map{|_, form, _| form}.join("\n")
     end
 
+    def require_login_redirect
+      login_path
+    end
+
     private
 
     def _login_response

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -289,6 +289,7 @@ describe 'Rodauth login feature' do
       r.on 'auth' do
         r.rodauth
       end
+      r.get('restricted'){rodauth.require_login}
       next unless session['login_email'] =~ /example/
       r.get('foo', :email){|e| "Logged In: #{e}"}
     end
@@ -308,6 +309,9 @@ describe 'Rodauth login feature' do
 
     visit '/auth/lout'
     click_button 'Logout'
+    page.current_path.must_equal '/auth/lin'
+
+    visit '/restricted'
     page.current_path.must_equal '/auth/lin'
   end
 


### PR DESCRIPTION
When login feature is enabled, it's expected that requiring login will redirect to the login page. This won't be the case if `login_route` changes. I thought it would be convenient to have it automatically match, so that the developer doesn't have to also update `require_login_redirect` in that case.
