### PR TITLE
[POC] Use `WebAuthn::RelyingParty`

### DIFF
--- a/rodauth.gemspec
+++ b/rodauth.gemspec
@@ -55,7 +55,7 @@ END
   s.add_development_dependency('rotp')
   s.add_development_dependency('rqrcode')
   s.add_development_dependency('jwt')
-  s.add_development_dependency('webauthn', '>=2')
+  s.add_development_dependency('webauthn', '>=3')
   s.add_development_dependency("minitest", '>=5.0.0')
   s.add_development_dependency("minitest-global_expectations")
   s.add_development_dependency("minitest-hooks", '>=1.1.0')


### PR DESCRIPTION
## Motivation/Background

Rodauth currently overrides internal WebAuthn methods in order to be able to allow for multiple origins. This feature is [officially supported by `webauthn` gem starting in its version `v3`](https://github.com/cedarcode/webauthn-ruby/blob/master/CHANGELOG.md#v300alpha1---2020-06-27) so we should be able to avoid overriding `WebAuthn` internal methods.

## Details

This PR just changes to use the new `webauthn` instance based configuration to support for multiple origins.  It feels to me that that should be all you need to do, but I might be missing something.

It also bumps `webauthn` required version to `v3`, but it shouldn't be hard to maintain compatibility with `v2` if desired as `v3` is backwards compatible. 

Furthermore, nothing changes that much from `v2` besides the required ruby version going from [`2.3` in `webauthn v2.0.0`](https://github.com/cedarcode/webauthn-ruby/blob/v2.0.0/webauthn.gemspec#L32) to [`2.5` in `webauthn v3.0.0`](https://github.com/cedarcode/webauthn-ruby/blob/v3.0.0/webauthn.gemspec#L34).