### PR TITLE
Fallback to account_id if session_value is not set for selecting active sessions

### DIFF
--- a/lib/rodauth/features/active_sessions.rb
+++ b/lib/rodauth/features/active_sessions.rb
@@ -198,7 +198,7 @@ module Rodauth
 
     def active_sessions_ds
       db[active_sessions_table].
-        where(active_sessions_account_id_column=>session_value)
+        where(active_sessions_account_id_column=>session_value || account_id)
     end
 
     def use_date_arithmetic?


### PR DESCRIPTION
When `active_sessions_ds` uses `session_value` to select active sessions, it doesn't return the sessions for not-logged in users. This makes helpers like `remove_all_active_sessions` ineffective. In such situations, we can use `account_id` as a fallback to select the active session.