### PR TITLE
Skip default session clearing in JWT mode

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -59,11 +59,9 @@ module Rodauth
     end
 
     def clear_session
-      super
-      if use_jwt?
-        session.clear
-        set_jwt
-      end
+      return super unless use_jwt?
+      session.clear
+      set_jwt
     end
 
     def jwt_secret


### PR DESCRIPTION
Originally, `#clear_session` in JWT feature was calling `super` to clear the session hash from the instance variable. However, in https://github.com/jeremyevans/rodauth/pull/140 an explicit `session.clear` was added, because `super` didn't handle sessions plugin being loaded.

This means it's not necessary to call `super` anymore. This behavior caused a [bug](https://github.com/janko/rodauth-omniauth/discussions/13#discussioncomment-8961467) when `rodauth-omniauth` is used with `rodauth-rails`, where `super` being called when clearing JWT session called Rails implementation. The root cause was ultimately in `rodauth-omniauth`, but I thought it would be useful to have this change as a safeguard for any plugin extending `#clear_session`.
