### PR TITLE
s/succesful/successful/g

### DIFF
--- a/doc/guides/render_confirmation.rdoc
+++ b/doc/guides/render_confirmation.rdoc
@@ -1,6 +1,6 @@
 = Render confirmation view
 
-Most Rodauth actions redirect and display a flash notice after they're succesfully performed. However, in some cases you may wish to render a view confirming that the action was succesful, for nicer user experience.
+Most Rodauth actions redirect and display a flash notice after they're successfully performed. However, in some cases you may wish to render a view confirming that the action was successful, for nicer user experience.
 
 For example, when the user creates an account, you might render a page with a call to action to verify their account. Assuming you've created an +account_created+ view template alongside your other Rodauth templates, you can configure the following:
 

--- a/doc/login.rdoc
+++ b/doc/login.rdoc
@@ -14,7 +14,7 @@ location.
 
 login_additional_form_tags :: HTML fragment containing additional form tags to use on the login form.
 login_button :: The text to use for the login button.
-login_error_flash :: The flash error to show for an unsuccesful login.
+login_error_flash :: The flash error to show for an unsuccessful login.
 login_error_status :: The response status to use when using an invalid login or password to login, 401 by default.
 login_form_footer_links :: An array of entries for links to show on the login page.  Each entry is an array of three elements, sort order (integer), link href, and link text.
 login_form_footer_links_heading :: A heading to show before the login form footer links.


### PR DESCRIPTION
Just noticed several typos for `succesful*`, so fixing these