### PR TITLE
prettify/simplify psql statements for `Using non-default schema` scenario

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -338,8 +338,8 @@ PostgreSQL sets up new tables in the public schema by default.
 If you would like to use separate schemas per user, you can do:
 
   psql -U postgres -c "DROP SCHEMA public;" ${DATABASE_NAME}
-  psql -U postgres -c "CREATE SCHEMA ${DATABASE_NAME} AUTHORIZATION ${DATABASE_NAME};" ${DATABASE_NAME}
-  psql -U postgres -c "CREATE SCHEMA ${DATABASE_NAME}_password AUTHORIZATION ${DATABASE_NAME}_password;" ${DATABASE_NAME}
+  psql -U postgres -c "CREATE SCHEMA AUTHORIZATION ${DATABASE_NAME};"          ${DATABASE_NAME}
+  psql -U postgres -c "CREATE SCHEMA AUTHORIZATION ${DATABASE_NAME}_password;" ${DATABASE_NAME}
   psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME} TO ${DATABASE_NAME}_password;" ${DATABASE_NAME}
   psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME}_password TO ${DATABASE_NAME};" ${DATABASE_NAME}
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -340,8 +340,8 @@ If you would like to use separate schemas per user, you can do:
   psql -U postgres -c "DROP SCHEMA public;" ${DATABASE_NAME}
   psql -U postgres -c "CREATE SCHEMA AUTHORIZATION ${DATABASE_NAME};"          ${DATABASE_NAME}
   psql -U postgres -c "CREATE SCHEMA AUTHORIZATION ${DATABASE_NAME}_password;" ${DATABASE_NAME}
-  psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME} TO ${DATABASE_NAME}_password;" ${DATABASE_NAME}
-  psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME}_password TO ${DATABASE_NAME};" ${DATABASE_NAME}
+  psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME}          TO ${DATABASE_NAME}_password;" ${DATABASE_NAME}
+  psql -U postgres -c "GRANT USAGE ON SCHEMA ${DATABASE_NAME}_password TO ${DATABASE_NAME};"          ${DATABASE_NAME}
 
 You'll need to modify the code to load the extension to specify the schema:
 


### PR DESCRIPTION
- simplify the `CREATE SCHEMA` statements (no need to repeat the schema name if `AUTHORIZATION` is the same
- prettify horizontal alignment (yeah sorry about the commit message; it's _horizontal_, not _vertical!_) so that it's easier (IMO) to see what's going on

(For the record, I did confirm with the pg docs ([15](https://www.postgresql.org/docs/15/sql-createschema.html) onwards) that this way of specifying `CREATE SCHEMA` works where you do not need to separately specify the schema name if the authorization is the same value (search for `Create a schema for user joe; the schema will also be named joe:`))