### PR TITLE
lib/rodauth/features/base.rb: add `throw_status` method that throws :rodauth_error without needing to set_field_error

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -648,6 +648,11 @@ module Rodauth
       throw :rodauth_error
     end
 
+    def throw_status(status)
+      set_response_error_status(status)
+      throw :rodauth_error
+    end
+
     def throw_error_status(status, field, error)
       set_response_error_status(status)
       throw_error(field, error)

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -643,14 +643,13 @@ module Rodauth
       set_response_error_status(status)
     end
 
-    def throw_error(field, error)
-      set_field_error(field, error)
+    def throw_rodauth_error
       throw :rodauth_error
     end
 
-    def throw_status(status)
-      set_response_error_status(status)
-      throw :rodauth_error
+    def throw_error(field, error)
+      set_field_error(field, error)
+      throw_rodauth_error
     end
 
     def throw_error_status(status, field, error)


### PR DESCRIPTION
as per https://github.com/jeremyevans/rodauth/discussions/412