### PR TITLE
set nice autofocus on login/password field (autofocus will go to first field with attribute set)

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -206,7 +206,7 @@ module Rodauth
         required = "required=\"required\""
       end
 
-      "<input #{opts[:attr]} #{autocomplete} #{inputmode} #{required} #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"#{field_class}#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\"/> #{formatted_field_error(param) unless opts[:skip_error_message]}"
+      "<input #{opts[:attr]} #{autocomplete} #{inputmode} #{required} #{field_attributes(param)} #{field_error_attributes(param)} type=\"#{type}\" class=\"#{field_class}#{add_field_error_class(param)}\" name=\"#{param}\" id=\"#{id}\" value=\"#{value}\" #{"autofocus" if opts[:autofocus]}/> #{formatted_field_error(param) unless opts[:skip_error_message]}"
     end
 
     def autocomplete_for_field?(_param)

--- a/templates/login-field.str
+++ b/templates/login-field.str
@@ -1,4 +1,4 @@
 <div class="form-group mb-3">
   <label for="login" class="form-label">#{rodauth.login_label}#{rodauth.input_field_label_suffix}</label>
-  #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_field_autocomplete_value)}
+  #{rodauth.input_field_string(rodauth.login_param, 'login', :type=>rodauth.login_input_type, :autocomplete=>rodauth.login_field_autocomplete_value, :autofocus=>true)}
 </div>

--- a/templates/password-field.str
+++ b/templates/password-field.str
@@ -1,4 +1,4 @@
 <div class="form-group mb-3">
   <label for="password" class="form-label">#{rodauth.password_label}#{rodauth.input_field_label_suffix}</label>
-  #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>rodauth.password_field_autocomplete_value)}
+  #{rodauth.input_field_string(rodauth.password_param, 'password', :type => 'password', :autocomplete=>rodauth.password_field_autocomplete_value, :autofocus=>true)}
 </div>


### PR DESCRIPTION
Note:
- I did not opt for the same approach as for `autocomplete`, `inputmode`, etc. because for HTML, setting `autofocus="<any string>"` will only serve to activate `autofocus`
- because it is ok to have `autofocus` on multiple fields (only the first field will get `autofocus`-ed), I opted to have `autofocus` for both the login, and the password field, so when `rodauth.skip_login_field_on_login?` is true, the autofocus then goes to the password field