### PR TITLE
Add `account_from_id` for loading account by id

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -85,6 +85,7 @@ use_request_specific_csrf_tokens? :: Whether to use request-specific CSRF tokens
 
 == Auth Methods
 
+account_from_id(id, status_id=nil) :: Retrieve the account hash for the given account id and status.
 account_from_login(login) :: Retrieve the account hash related to the given login or nil if no login matches.
 account_from_session :: Retrieve the account hash related to the currently logged in session.
 account_id :: The primary key value of the current account.

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -116,6 +116,7 @@ module Rodauth
     )
 
     auth_private_methods(
+      :account_from_id,
       :account_from_login,
       :account_from_session,
       :convert_token_id,
@@ -383,6 +384,10 @@ module Rodauth
 
     def account_from_session
       @account = _account_from_session
+    end
+
+    def account_from_id(id, status_id=nil)
+      @account = _account_from_id(id, status_id)
     end
 
     def check_csrf
@@ -737,6 +742,12 @@ module Rodauth
     def _account_from_session
       ds = account_ds(session_value)
       ds = ds.where(account_session_status_filter) unless skip_status_checks?
+      ds.first
+    end
+
+    def _account_from_id(id, status_id=nil)
+      ds = account_ds(id)
+      ds = ds.where(account_status_column=>status_id) if status_id && !skip_status_checks?
       ds.first
     end
 

--- a/lib/rodauth/features/email_base.rb
+++ b/lib/rodauth/features/email_base.rb
@@ -74,9 +74,7 @@ module Rodauth
          ((!hmac_secret || allow_raw_email_token?) && timing_safe_eql?(key, actual))
         return
       end
-      ds = account_ds(id)
-      ds = ds.where(account_status_column=>status_id) if status_id && !skip_status_checks?
-      ds.first
+      _account_from_id(id, status_id)
     end
   end
 end

--- a/lib/rodauth/features/internal_request.rb
+++ b/lib/rodauth/features/internal_request.rb
@@ -183,9 +183,7 @@ module Rodauth
     def account_from_key(token, status_id=nil)
       return super unless session_value
       return unless yield session_value
-      ds = account_ds(session_value)
-      ds = ds.where(account_status_column=>status_id) if status_id && !skip_status_checks?
-      ds.first
+      _account_from_id(session_value, status_id)
     end
 
     def _set_internal_request_return_value(value)
@@ -210,7 +208,7 @@ module Rodauth
     end
 
     def _set_login_param_from_account
-      if session_value && !params[login_param] && (account = account_ds(session_value).first)
+      if session_value && !params[login_param] && (account = _account_from_id(session_value))
         params[login_param] = account[login_column]
       end
     end

--- a/lib/rodauth/features/webauthn_autofill.rb
+++ b/lib/rodauth/features/webauthn_autofill.rb
@@ -53,7 +53,7 @@ module Rodauth
         throw_error_reason(:invalid_webauthn_id, invalid_field_error_status, webauthn_auth_param, webauthn_invalid_webauthn_id_message)
       end
 
-      @account = account_ds(account_id).first
+      account_from_id(account_id)
     end
 
     def webauthn_login_options?


### PR DESCRIPTION
This is useful in when delivering emails in a background job, where the background job is given the account ID. In that case, the Rodauth instance needs to be initialized outside of a request, and account and token loaded into it.

This is what rodauth-rails has been doing so far:

```rb
rodauth = RodauthApp.rodauth.allocate
rodauth.instance_eval { @account = account_ds(account_id).first! }
```

With the new method it can be cleaner:

```rb
rodauth = RodauthApp.rodauth.allocate
rodauth.account_from_id(account_id)
```

There are also a few places within Rodauth that can make use of this method.
