### PR TITLE
Allow sending webauthn modify emails outside of a request

### DIFF
--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -489,7 +489,7 @@ module Rodauth
     end
 
     def webauthn_account_id
-      session_value
+      account ? account_id : session_value
     end
 
     def webauthn_user_ids_ds

--- a/lib/rodauth/features/webauthn_login.rb
+++ b/lib/rodauth/features/webauthn_login.rb
@@ -89,9 +89,5 @@ module Rodauth
       end
       forms
     end
-
-    def webauthn_account_id
-      super || account_id
-    end
   end
 end

--- a/lib/rodauth/features/webauthn_verify_account.rb
+++ b/lib/rodauth/features/webauthn_verify_account.rb
@@ -38,9 +38,5 @@ module Rodauth
       @webauthn_credential = webauthn_setup_credential_from_form_submission
       add_webauthn_credential(@webauthn_credential)
     end
-
-    def webauthn_account_id
-      super || account_id
-    end
   end
 end


### PR DESCRIPTION
In a background job, we need to allocate a Rodauth instance without any Rack request information if we wanted to use it to render emails. There the session will not be available, but the account can be loaded into the Rodauth instance.

```rb
# this is how rodauth-rails recommends sending emails in background job
rodauth = RodauthApp.rodauth.allocate
rodauth.account_from_id(account_id)
rodauth.webauthn_authenticator_added_email_body
```

In order for the webauthn modify emails to render successfully in this case, `#webauthn_account_id` needs to take the loaded account if available.

Not sure if it makes sense writing tests for this scenario, as I'm not sure how common this approach is outside of rodauth-rails (I don't know of an alternative).
