### PR TITLE
Add rodauth-openapi to the website

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -107,9 +107,10 @@
   <li><a href="https://gitlab.com/honeyryderchuck/rodauth-select-account">rodauth-select-account</a>: Support logging into multiple accounts in the same session.</li>
 </ul>
 
-<h2 id="external-guides">External Guides</h2>
+<h2 id="external-documentation">External Documentation</h2>
 
 <ul>
+  <li><a href="https://github.com/janko/rodauth-openapi">rodauth-openapi</a>: Generate OpenAPI documentation for your Rodauth endpoints</li>
   <li><a href="https://documenter.getpostman.com/view/26686011/2s9YC7SWn9">Documentation of Rodauth routes for JSON requests</a></li>
 </ul>
 


### PR DESCRIPTION
It's not technically a "feature", since it doesn't provide any authentication functionality. It's more like tooling, and it made sense to put it together with the Postman documentation, since it's an alternative to that. While the Postman documentation is static and doesn't adapt to route/param changes, this is dynamic based on your actual Rodauth configuration.
