### PR TITLE
Allow disabling WebAuthn autofill UI

### DIFF
--- a/doc/webauthn_autofill.rdoc
+++ b/doc/webauthn_autofill.rdoc
@@ -10,6 +10,7 @@ independently from the autofill UI.
 
 == Auth Value Methods
 
+webauthn_autofill? :: Whether to activate the autofill UI on the login page.
 webauthn_autofill_js :: The javascript code to execute on the login page to enable autofill UI.
 webauthn_autofill_js_route :: The route to the webauthn autofill javascript file.
 webauthn_invalid_webauthn_id_message :: The error message to show when provided WebAuthn ID wasn't found in the database.

--- a/lib/rodauth/features/webauthn_autofill.rb
+++ b/lib/rodauth/features/webauthn_autofill.rb
@@ -4,6 +4,7 @@ module Rodauth
   Feature.define(:webauthn_autofill, :WebauthnAutofill) do
     depends :webauthn_login
 
+    auth_value_method :webauthn_autofill?, true
     auth_value_method :webauthn_autofill_js, File.binread(File.expand_path('../../../../javascript/webauthn_autofill.js', __FILE__)).freeze
 
     translatable_method :webauthn_invalid_webauthn_id_message, "no webauthn key with given id found"
@@ -37,7 +38,7 @@ module Rodauth
 
     def _login_form_footer
       footer = super
-      footer += render("webauthn-autofill") unless valid_login_entered?
+      footer += render("webauthn-autofill") if webauthn_autofill? && !valid_login_entered?
       footer
     end
 

--- a/spec/webauthn_autofill_spec.rb
+++ b/spec/webauthn_autofill_spec.rb
@@ -84,6 +84,20 @@ describe 'Rodauth webauthn_autofill feature' do
     page.find("#login")[:autocomplete].must_equal "email"
   end
 
+  it "should allow disabling autofill" do
+    rodauth do
+      enable :webauthn_autofill
+      hmac_secret '123'
+      webauthn_autofill? false
+    end
+    roda do |r|
+      r.rodauth
+      view :content=>""
+    end
+    visit "/login"
+    page.has_css?("#webauthn-auth-form").must_equal false
+  end
+
   it "should allow webauthn autofill via json" do
     rodauth do
       enable :webauthn_autofill, :logout


### PR DESCRIPTION
This is useful when the developer wants the ability to offer WebAuthn authentication without asking for login, but considers the autofill UI too magical for the end user, and would prefer to display an explicit "login via passkey" button instead.

The autofill UI has become even more magical in recent browser/OS versions, where the user is asked to authenticate via WebAuthn as soon as the login page is loaded. Previously, Chrome would display a passkey option in a dropdown after focusing the login field, but this is no longer the case.

This ties onto our discussion in https://github.com/jeremyevans/rodauth/discussions/363.
