### PR TITLE
Disable CSRF protection for JSON requests

### DIFF
--- a/doc/json.rdoc
+++ b/doc/json.rdoc
@@ -23,11 +23,11 @@ to the JSON response:
     json_response[:error_reason] = reason
   end
 
-The session state is managed in the rack session, so make sure that
-CSRF protection is enabled. This will be the case when passing the
-<tt>json: true</tt> option when loading the rodauth plugin. If you
-want to only handle JSON requests, set <tt>only_json? true</tt> in
-your rodauth configuration.
+The session state is managed in the rack session (just like in HTML mode), with
+CSRF protection being disabled by default for JSON requests. HTML mode is still
+available when <tt>json: true</tt> option is passed to the rodauth plugin. If
+you want to only handle JSON requests, set <tt>only_json? true</tt> in your
+rodauth configuration.
 
 If you want token-based authentication sent via the Authorization
 header, consider using the jwt feature.

--- a/lib/rodauth/features/json.rb
+++ b/lib/rodauth/features/json.rb
@@ -72,6 +72,11 @@ module Rodauth
 
     private
 
+    def check_csrf?
+      return false if use_json?
+      super
+    end
+
     def _set_otp_unlock_info
       if use_json?
         json_response[:num_successes] = otp_unlock_num_successes

--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -101,11 +101,6 @@ module Rodauth
 
     private
 
-    def check_csrf?
-      return false if use_jwt?
-      super
-    end
-
     def _jwt_decode_opts
       jwt_decode_opts
     end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -115,6 +115,20 @@ describe 'Rodauth json feature' do
     json_request("/login", :headers=>{'HTTP_ACCEPT'=>'application/vnd.api+json'}, :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
   end
 
+  it "should not check CSRF for json requests" do
+    rodauth do
+      enable :login, :json
+      only_json? false
+    end
+    roda(:json_html) do |r|
+      r.rodauth
+      view(:content=>'1')
+    end
+
+    res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
+    res.must_equal true
+  end
+
   it "should have field error and error flash work correctly when using json feature for non-json requests" do
     mpl = false
     rodauth do

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -61,7 +61,7 @@ describe 'Rodauth login feature' do
       view(:content=>'1')
     end
 
-    res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789', :csrf=>false).must_equal [200, {"success"=>'You have been logged in'}]
+    res = json_request("/login", :login=>'foo@example.com', :password=>'0123456789').must_equal [200, {"success"=>'You have been logged in'}]
     res.must_equal true
   end
 


### PR DESCRIPTION
Currently, CSRF protection is only disabled for JWT requests, as those use token-based instead of cookie-based authentication. However, JSON APIs that require `Content-Type: application/json` and have reasonable CORS restrictions don't appear to be vulnerable to CSRF attacks.

Since handling CSRF tokens isn't trivial to do on the client side, we can reduce friction by disabling CSRF protection by default for _all_ JSON requests (including JWT).

This is a follow-up to the discussion in https://github.com/jeremyevans/rodauth/discussions/448.
