### PR TITLE
Add method for when 2nd factor auth is pending

### DIFF
--- a/demo-site/views/index.erb
+++ b/demo-site/views/index.erb
@@ -16,7 +16,7 @@
     <% if rodauth.logged_in_via_remember_key? %>
       <li><a href="/confirm-password">Confirm Password</a></li>
     <% end %>
-    <% if rodauth.uses_two_factor_authentication? && !rodauth.two_factor_authenticated? %>
+    <% if rodauth.two_factor_partially_authenticated? %>
       <li><a href="/multifactor-auth">Authenticate Using Additional Factor</a></li>
     <% else %>
       <li><a href="/multifactor-manage">Manage Multifactor Authentication</a></li>

--- a/lib/rodauth/features/two_factor_base.rb
+++ b/lib/rodauth/features/two_factor_base.rb
@@ -124,23 +124,12 @@ module Rodauth
     end
 
     def authenticated?
-      # False if not authenticated via single factor
-      return false unless super
-
-      # True if already authenticated via 2nd factor
-      return true if two_factor_authenticated?
-
-      # True if authenticated via single factor and 2nd factor not setup 
-      !uses_two_factor_authentication?
+      super && !two_factor_partially_authenticated?
     end
 
     def require_authentication
       super
-
-      # Avoid database query if already authenticated via 2nd factor
-      return if two_factor_authenticated?
-
-      require_two_factor_authenticated if uses_two_factor_authentication?
+      require_two_factor_authenticated if two_factor_partially_authenticated?
     end
 
     def require_two_factor_setup
@@ -186,6 +175,10 @@ module Rodauth
       else
         true
       end
+    end
+
+    def two_factor_partially_authenticated?
+      logged_in? && !two_factor_authenticated? && uses_two_factor_authentication?
     end
 
     def two_factor_authenticated?


### PR DESCRIPTION
This is useful for when applications want to modify configuration depending on whether 2FA is pending. For example, the Rails demo app currently redirects directly to 2FA after login:

```rb
login_redirect { uses_two_factor_authentication? && !two_factor_authenticated? ? two_factor_auth_required_redirect : super() }
login_notice_flash { uses_two_factor_authentication? && !two_factor_authenticated? ? "Please authenticate with 2nd factor" : super() }
```

(It's necessary to check `!two_factor_authenticated?` here as well, because passkey login can authenticate both factors at once.) With this method available, the code can be simplified:

```rb
login_redirect { two_factor_authentication_pending? ? two_factor_auth_required_redirect : super() }
login_notice_flash { two_factor_authentication_pending? ? "Please authenticate with 2nd factor" : super() }
```
