### PR TITLE
Add guide for configuring case insensitive logins

### DIFF
--- a/doc/guides/case_insensitive_login.rdoc
+++ b/doc/guides/case_insensitive_login.rdoc
@@ -1,0 +1,13 @@
+= Case insensitive logins
+
+If your database schema doesn't support case insensitive logins, you can tell
+Rodauth to automatically lowercase login param values during authentication and
+persistence via the +normalize_login+ configuration option:
+
+  normalize_login(&:downcase)
+
+Of the four database types Rodauth officially supports (PostgreSQL, MySQL,
+Microsoft SQL Server, and SQLite), only SQLite does not support a case
+insensitive column for storing logins by default. However, other databases could
+be configured to not use a case insensitive column for logins by default, in
+which case you would want to use this setting.

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -69,6 +69,7 @@
   <li><a href="rdoc/files/doc/guides/admin_activation_rdoc.html">Require account verification by admin</a></li>
   <li><a href="rdoc/files/doc/guides/already_authenticated_rdoc.html">Skip login page if already authenticated</a></li>
   <li><a href="rdoc/files/doc/guides/alternative_login_rdoc.html">Use a non-email login</a></li>
+  <li><a href="rdoc/files/doc/guides/case_insensitive_login_rdoc.html">Case insensitive login</a></li>
   <li><a href="rdoc/files/doc/guides/change_table_and_column_names_rdoc.html">Change table and column names</a></li>
   <li><a href="rdoc/files/doc/guides/create_account_programmatically_rdoc.html">Create an account record programmatically</a></li>
   <li><a href="rdoc/files/doc/guides/delay_password_rdoc.html">Set password when verifying account</a></li>


### PR DESCRIPTION
As discussed [here](https://github.com/jeremyevans/rodauth/commit/eabfa697e9cf1871d6468c9940685579ad568b6d#commitcomment-149180108), I added a guide for configuring case insensitive logins, as an alternative to a new feature.
