### PR TITLE
Update website documentation external link to rodauth-oauth

### DIFF
--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -101,7 +101,7 @@
   <li><a href="https://github.com/janko/rodauth-guest">rodauth-guest</a>: Provides guest user functionality.</li>
   <li><a href="https://github.com/janko/rodauth-i18n">rodauth-i18n</a>: Provides I18n integration and translations.</li>
   <li><a href="https://github.com/janko/rodauth-model">rodauth-model</a>: Provides password attribute and associations for account model.</li>
-  <li><a href="https://gitlab.com/honeyryderchuck/rodauth-oauth">rodauth-oauth</a>: Implements the OAuth 2.0 protocol on top of Rodauth.</li>
+  <li><a href="https://gitlab.com/os85/rodauth-oauth">rodauth-oauth</a>: Implements the OAuth 2.0 protocol on top of Rodauth.</li>
   <li><a href="https://github.com/janko/rodauth-omniauth">rodauth-omniauth</a>: Provides login & registration with multiple external providers using OmniAuth.</li>
   <li><a href="https://github.com/janko/rodauth-pwned">rodauth-pwned</a>: Checks passwords against the Pwned Passwords API.</li>
   <li><a href="https://github.com/janko/rodauth-rails">rodauth-rails</a>: Provides Rails integration for Rodauth.</li>


### PR DESCRIPTION
This repository has moved:

> Project 'honeyryderchuck/rodauth-oauth' was moved to 'os85/rodauth-oauth'. Please update any links and bookmarks that may still have the old path.

![image](https://github.com/user-attachments/assets/2af8b702-ec18-4e0d-87d5-297b87247e80)
