### PR TITLE
Raise error when attempting to render, but rendering was disabled

### DIFF
--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -3,6 +3,8 @@
 require 'securerandom'
 
 module Rodauth
+  class ConfigurationError < StandardError; end
+
   def self.lib(opts={}, &block) 
     require 'roda'
     c = Class.new(Roda)

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -930,6 +930,10 @@ module Rodauth
     end
 
     def _view(meth, page)
+      unless scope.respond_to?(meth)
+        raise ConfigurationError, "attempted to render a built-in view/email template (#{page.inspect}), but rendering is disabled"
+      end
+
       scope.send(meth, _view_opts(page))
     end
   end

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -766,7 +766,7 @@ module Rodauth
     end
 
     def compute_raw_hmac(data)
-      raise ArgumentError, "hmac_secret not set" unless hmac_secret
+      raise ConfigurationError, "hmac_secret not set" unless hmac_secret
       compute_raw_hmac_with_secret(data, hmac_secret)
     end
 
@@ -885,7 +885,7 @@ module Rodauth
 
     def require_response(meth)
       send(meth)
-      raise RuntimeError, "#{meth.to_s.sub(/\A_/, '')} overridden without returning a response (should use redirect or request.halt). This is a bug in your Rodauth configuration, not a bug in Rodauth itself."
+      raise ConfigurationError, "#{meth.to_s.sub(/\A_/, '')} overridden without returning a response (should use redirect or request.halt)."
     end
 
     def set_session_value(key, value)

--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -64,7 +64,7 @@ module Rodauth
     end
 
     def jwt_secret
-      raise ArgumentError, "jwt_secret not set"
+      raise ConfigurationError, "jwt_secret not set"
     end
 
     def jwt_session_hash

--- a/lib/rodauth/features/sms_codes.rb
+++ b/lib/rodauth/features/sms_codes.rb
@@ -514,7 +514,7 @@ module Rodauth
     end
 
     def sms_send(phone, message)
-      raise NotImplementedError, "sms_send needs to be defined in the Rodauth configuration for SMS sending to work"
+      raise ConfigurationError, "sms_send needs to be defined in the Rodauth configuration for SMS sending to work"
     end
 
     def update_sms(values)

--- a/spec/change_login_spec.rb
+++ b/spec/change_login_spec.rb
@@ -250,6 +250,6 @@ describe 'Rodauth change_login feature' do
     visit '/change-login'
     fill_in 'Login', :with=>'foo3@example.com'
     fill_in 'Confirm Login', :with=>'foo3@example.com'
-    proc{click_button 'Change Login'}.must_raise RuntimeError
+    proc{click_button 'Change Login'}.must_raise Rodauth::ConfigurationError
   end
 end

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -558,7 +558,7 @@ describe 'Rodauth login feature' do
     rodauth do
       enable :login, :logout
       json_response_custom_error_status? false
-      jwt_secret{proc{super()}.must_raise ArgumentError; "1"}
+      jwt_secret{proc{super()}.must_raise Rodauth::ConfigurationError; "1"}
     end
     roda(:jwt) do |r|
       r.rodauth

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -1367,7 +1367,7 @@ describe 'Rodauth' do
       rodauth.compute_hmac("secret")
     end
 
-    error = proc{visit "/"}.must_raise(ArgumentError)
+    error = proc{visit "/"}.must_raise(Rodauth::ConfigurationError)
     error.message.must_equal "hmac_secret not set"
   end
 

--- a/spec/rodauth_spec.rb
+++ b/spec/rodauth_spec.rb
@@ -856,6 +856,14 @@ describe 'Rodauth' do
     c.ancestors.map(&:to_s).wont_include 'Roda::RodaPlugins::RouteCsrf::InstanceMethods'
   end
 
+  it "raises error when rendering is disabled" do
+    c = Class.new(Roda)
+    c.plugin(:rodauth, :render=>false){}
+    rodauth = c.new({}).rodauth
+    error = proc{rodauth.render("login")}.must_raise Rodauth::ConfigurationError
+    error.message.must_include "attempted to render"
+  end
+
   it "should inherit rodauth configuration in subclass" do
     auth_class = nil
     no_freeze!

--- a/spec/two_factor_spec.rb
+++ b/spec/two_factor_spec.rb
@@ -28,7 +28,7 @@ describe 'Rodauth two factor feature' do
       end
 
       sms_send do |phone, msg|
-        proc{super(phone, msg)}.must_raise NotImplementedError
+        proc{super(phone, msg)}.must_raise Rodauth::ConfigurationError
         sms_phone = phone
         sms_message = msg
       end


### PR DESCRIPTION
When configuring Rodauth plugin with `render: false`, it could happen that Rodauth would attempt to render a built-in view/email template:

* attempting to render a built-in email template is possible for JSON or internal requests
* external gem might incorrectly attempt to render a view template in JSON or internal requests
* in Rails apps, people would typically use Action View for rendering view/email templates, and they might miss some when disabling Tilt

Currently, Rodauth raises a rather cryptic:

```
NoMethodError: undefined method `parse_template_opts' for an instance of #<Class:0x000000011d9e3f40>
```

I initially started adding the error in rodauth-rails, but I thought it would be beneficial to have this in Rodauth itself. And for this it made sense to me to add a custom error class.

Technically, this doesn't cover the `#button` case, but those are only rendered within view templates, so the error should already be raised by `#_view` beforehand.