### PR TITLE
Add guide on customizing email requirements

### DIFF
--- a/doc/guides/email_requirements.rdoc
+++ b/doc/guides/email_requirements.rdoc
@@ -1,0 +1,35 @@
+= Customize email requirements
+
+By default, Rodauth requires emails to have at least 3 characters and at most
+255 bytes. You can modify the minimum and maximum length:
+
+  plugin :rodauth do
+    enable :login, :logout, :create_account
+
+    # Require emails to have at least 5 characters
+    login_minimum_length 5
+
+    # Don't allow emails longer than 100 characters
+    login_maximum_length 100
+
+    # Don't allow emails larger than 200 bytes
+    login_maximum_bytes 200
+  end
+
+You can also override email address validation, and do more advanced email
+checks, such as checking whether the email address exists using the
+{Truemail}[https://github.com/truemail-rb/truemail] gem:
+
+  require "truemail"
+
+  Truemail.configure do |config|
+    config.verifier_email = "verifier@example.com"
+  end
+
+  plugin :rodauth do
+    enable :login, :logout, :create_account
+
+    login_valid_email? do |email|
+      super(email) && Truemail.valid?(email)
+    end
+  end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -73,6 +73,7 @@
   <li><a href="rdoc/files/doc/guides/create_account_programmatically_rdoc.html">Create an account record programmatically</a></li>
   <li><a href="rdoc/files/doc/guides/delay_password_rdoc.html">Set password when verifying account</a></li>
   <li><a href="rdoc/files/doc/guides/email_only_rdoc.html">Allow only email authentication</a></li>
+  <li><a href="rdoc/files/doc/guides/email_requirements_rdoc.html">Customize email requirements</a></li>
   <li><a href="rdoc/files/doc/guides/i18n_rdoc.html">Translate with I18n gem</a></li>
   <li><a href="rdoc/files/doc/guides/links_rdoc.html">Display authentication links</a></li>
   <li><a href="rdoc/files/doc/guides/login_return_rdoc.html">Redirect to original page after login</a></li>


### PR DESCRIPTION
It's useful to know how to extend email requirements, for example verify whether the email exists to guard against spammers. It complements the existing guide on customizing password requirements.
