### PR TITLE
Make rodauth.has_password? method public

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 === master
+* Make rodauth.has_password? method public (enescakir) (#461)
 
 * Fix strict_unused_block warnings when running specs on Ruby 3.4 (jeremyevans)
 

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -542,6 +542,12 @@ module Rodauth
       has_password? ? ['password'] : []
     end
 
+    def has_password?
+      return @has_password if defined?(@has_password)
+      return false unless account || session_value
+      @has_password = !!get_password_hash
+    end
+
     private
 
     def _around_rodauth
@@ -716,12 +722,6 @@ module Rodauth
       else
         name
       end
-    end
-
-    def has_password?
-      return @has_password if defined?(@has_password)
-      return false unless account || session_value
-      @has_password = !!get_password_hash
     end
 
     def password_hash_using_salt(password, salt)


### PR DESCRIPTION
I needed this method when integrating rodauth-omniauth into our project.

If an account is created via omniauth, it doesn't have a password. In this case, I prefer to display "Create Password" instead of "Change Password".

Additionally, if the omniauth provider is the last authentication method, including the password, I aim to block to disconnect it.

Therefore, I believe this method is beneficial to have in public.