### PR TITLE
Fix compatibility with JWT 2.10+

### DIFF
--- a/lib/rodauth/features/jwt.rb
+++ b/lib/rodauth/features/jwt.rb
@@ -105,7 +105,7 @@ module Rodauth
       jwt_decode_opts
     end
 
-    if JWT::VERSION::MAJOR > 2 || (JWT::VERSION::MAJOR == 2 && JWT::VERSION::MINOR >= 4)
+    if JWT.gem_version >= Gem::Version.new("2.4")
       def _jwt_decode_secrets
         secrets = [jwt_secret, jwt_old_secret]
         secrets.compact!

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -131,7 +131,7 @@ describe 'Rodauth login feature' do
     old_secret = '1'
     res = json_request("/", :method=>'GET')
     res.must_equal [200, ['true']]
-  end if JWT::VERSION::MAJOR > 2 || (JWT::VERSION::MAJOR == 2 && JWT::VERSION::MINOR >= 4)
+  end if JWT.gem_version >= Gem::Version.new('2.4')
 
   it "should require Accept contain application/json if jwt_check_accept? is true and Accept is present" do
     warning = nil


### PR DESCRIPTION
In JWT 2.10.0, the `JWT::VERSION::{MAJOR,MINOR,TINY,PRE}` constants were silently made private (see https://github.com/jwt/ruby-jwt/commit/e180765b56cb06407b39a6291d7364176f58dc0a), so use `JWT.gem_version` instead.
