### PR TITLE
docs: `configuration_eval` -> `configuration_module_eval`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1514,7 +1514,7 @@ use the following basic structure
         end
       end
 
-      configuration_eval do
+      configuration_module_eval do
         # define additional configuration specific methods here, if any
       end
 

--- a/doc/CHANGELOG.old
+++ b/doc/CHANGELOG.old
@@ -350,7 +350,7 @@
 
 * Add auth_class_eval to configuration block for adding custom methods (jeremyevans)
 
-* Add configuration_eval to feature definitions for adding custom configuration methods (jeremyevans)
+* Add configuration_module_eval to feature definitions for adding custom configuration methods (jeremyevans)
 
 * Allow close_account feature to optionally delete accounts (jeremyevans)
 


### PR DESCRIPTION
I was looking at the docs for custom features today and noted an example usage of `configuration_eval`. I wasn't totally sure how it should be used so searched the source for it and couldn't find any usages. Digging into the source code and the commit which introduced this term to the changelog and README, I think this was a typo for `configuration_module_eval`.