### PR TITLE
Add after_no_matching_login hook

### DIFF
--- a/doc/base.rdoc
+++ b/doc/base.rdoc
@@ -93,6 +93,7 @@ account_from_session :: Retrieve the account hash related to the currently logge
 account_id :: The primary key value of the current account.
 account_session_value :: The primary value of the current account to store in the session when logging in.
 after_login :: Run arbitrary code after a successful login.
+after_no_matching_login :: Run arbitrary code after a login failure due to an invalid login.
 after_login_failure :: Run arbitrary code after a login failure due to an invalid password.
 already_logged_in :: What action to take if you are already logged in and attempt to access a page that only makes sense if you are not logged in.
 around_rodauth(&block) :: Run arbitrary code around handling any rodauth route.  Call <tt>super(&block)</tt> for Rodauth to handle the action.

--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -6,6 +6,7 @@ require 'rack/utils'
 module Rodauth
   Feature.define(:base, :Base) do
     after 'login'
+    after 'no_matching_login'
     after 'login_failure'
     before 'login'
     before 'login_attempt'

--- a/lib/rodauth/features/http_basic_auth.rb
+++ b/lib/rodauth/features/http_basic_auth.rb
@@ -42,6 +42,7 @@ module Rodauth
 
       catch_error do
         unless account_from_login(username)
+          after_no_matching_login
           throw_basic_auth_error(login_param, no_matching_login_message)
         end
 

--- a/lib/rodauth/features/login.rb
+++ b/lib/rodauth/features/login.rb
@@ -47,6 +47,7 @@ module Rodauth
 
         catch_error do
           unless account_from_login(login_param_value)
+            after_no_matching_login
             throw_error_reason(:no_matching_login, no_matching_login_error_status, login_param, no_matching_login_message)
           end
 

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -678,4 +678,20 @@ describe 'Rodauth login feature' do
       app.rodauth.login(:account_login=>'foo@example.com', :password=>'012345678')
     end.must_raise Rodauth::InternalRequestError
   end
+
+  it "should call the after_no_matching_login hook" do
+    rodauth do
+      enable :login
+      template_opts layout_opts: { path: 'spec/views/layout-other.str' }
+      after_no_matching_login do
+        flash.now["error2"] = "Logging failed attempt for #{login_param_value}"
+      end
+    end
+    roda do |r|
+      r.rodauth
+    end
+
+    login(:login=>'foo-bar', :pass=>'banana')
+    page.html.must_include("Logging failed attempt for foo-bar")
+  end
 end


### PR DESCRIPTION
In order to log failed login attempts, a callback for a non-matching login would be helpful. 

Please advise if there is a better place to put this.