### PR TITLE
Fix `jwt_refresh` refresh endpoint returning 400 but also a token

### DIFF
--- a/lib/rodauth/features/jwt_refresh.rb
+++ b/lib/rodauth/features/jwt_refresh.rb
@@ -69,6 +69,9 @@ module Rodauth
 
     def set_jwt_token(token)
       super
+
+      return unless @current_route
+
       if json_response[json_response_error_key]
         json_response.delete(jwt_access_token_key)
       else

--- a/spec/jwt_refresh_spec.rb
+++ b/spec/jwt_refresh_spec.rb
@@ -680,4 +680,19 @@ describe 'Rodauth login feature' do
 
     json_request('/').must_equal [200, {"authenticated_by"=>["password"]}]
   end
+
+  it "should not leak access_token in the body when set_jwt_token is called outside a rodauth route" do
+    rodauth do
+      enable :login, :jwt_refresh, :session_expiration
+    end
+    roda(:jwt) do |r|
+      rodauth.check_session_expiration
+      r.rodauth
+    end
+
+    jwt_refresh_login
+
+    res = json_request("/jwt-refresh", :refresh_token=>'invalid')
+    res.must_equal [400, {"error"=>"invalid JWT refresh token"}]
+  end
 end


### PR DESCRIPTION
With our current setup:

```ruby
        class RodauthApp < Roda
          use Middlewares::AccountSelector

          plugin :rodauth, json: :only do
            enable :login, :jwt, :jwt_refresh, :session_expiration

            prefix '/api'
[...]
            allow_refresh_with_expired_jwt_access_token? true

[...]
          end

          route do |r|
            rodauth.check_session_expiration
            r.rodauth
          end
        end
```

which we mount on the main app under `/api`, we are getting the following behaviour:

```bash
curl -v http://localhost:3000/api/jwt-refresh -H 'authorization: Bearer validAccessToken' -H 'content-type: application/json' -d '{"refreshToken":"invalidRefreshToken"}'
[...]
< HTTP/1.1 401 Unauthorized
< authorization: newAccessToken
[...]
{"token":"newAccessToken","errors":[{"status":"401","code":"unauthorized","detail":"invalid JWT refresh token"}]}%
```

The `session_expiration` feature's `check_session_expiration` runs before `r.rodauth` and calls [`set_session_value(last_session_activity_at, now)`](https://github.com/jeremyevans/rodauth/blob/665751bf721fc023123f8630f632b55f9827500a/lib/rodauth/features/session_expiration.rb#L31) to bump activity. [`set_session_value`](https://github.com/jeremyevans/rodauth/blob/665751bf721fc023123f8630f632b55f9827500a/lib/rodauth/features/jwt.rb#L133-L137) chains into `set_jwt` → `set_jwt_token`, which [`jwt_refresh` overrides](https://github.com/jeremyevans/rodauth/blob/665751bf721fc023123f8630f632b55f9827500a/lib/rodauth/features/jwt_refresh.rb#L70-L77) to write the fresh JWT into both the authorization header and json_response['token'].
At that point `json_response[json_response_error_key]` isn't set yet, so the override takes the "no error" branch and stamps the body. The refresh route then enters the invalid-token branch and sets the error, but it calls [`_return_json_response`](https://github.com/jeremyevans/rodauth/blob/665751bf721fc023123f8630f632b55f9827500a/lib/rodauth/features/json.rb#L210-L214) which bypasses [the jwt.rb `return_json_response`](https://github.com/jeremyevans/rodauth/blob/665751bf721fc023123f8630f632b55f9827500a/lib/rodauth/features/jwt.rb#L145-L148) override that would re-run `set_jwt_token` and clean up the body.

The proposed fix makes sure the jwt is not set outside of Rodauth's routing, which solves the issue. The other alternative I can see is relying on `return_json_response` which would solve the issue as well, but would make redundant writes/checks.