### PR TITLE
Require `rack` in base feature so Rack.release is defined

### DIFF
--- a/lib/rodauth/features/base.rb
+++ b/lib/rodauth/features/base.rb
@@ -1,7 +1,17 @@
 # frozen-string-literal: true
 
-require 'rack/request'
-require 'rack/utils'
+begin
+  require "rack/version"
+rescue LoadError
+  require "rack"
+else
+  if Rack.release >= '3'
+    require "rack/request"
+    require "rack/utils"
+  else
+    require "rack"
+  end
+end
 
 module Rodauth
   Feature.define(:base, :Base) do


### PR DESCRIPTION
## Problem
Loading the base feature raises `NoMethodError: undefined method 'release' for module Rack` when no other code in the process has done a full `require 'rack'` first.

[lib/rodauth/features/base.rb:589](https://github.com/jeremyevans/rodauth/blob/407dd7b191cf0028626136524c555e62f6416756/lib/rodauth/features/base.rb#L588) references `Rack.release`, but the file only requires `rack/request` and `rack/utils`. Since Rack 3.0, `Rack.release` is defined in `rack/version.rb`, and that file is loaded only by `lib/rack.rb` — no `rack/<subpath>` require pulls it in.

The bug is hidden in rodauth's own specs because `spec/spec_helper.rb` loads `rack/test` / `capybara`, which transitively `require 'rack'`. Clients that call `Rodauth::Auth.configure` without those (e.g. [rodauth-model](https://github.com/janko/rodauth-model)) hit it immediately.

### Reproduction
```ruby
require 'rodauth'
Class.new(Rodauth::Auth).configure { enable :base }
# => NoMethodError: undefined method 'release' for module Rack
```

## Fix
Replace the partial requires with `require 'rack'`. `Rack::Request` and `Rack::Utils` remain available since `lib/rack.rb` loads them.