### PR TITLE
Exclude nil instance variables from `#inspect` output on Ruby 4+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Override instance_variables_to_inspect on Ruby 4+ to exclude nil instance variables (janko)
+
 * Work with Roda shape_friendly plugin (jeremyevans)
 
 * Add transaction_opts configuration method for defining transaction options (jeremyevans)

--- a/lib/rodauth.rb
+++ b/lib/rodauth.rb
@@ -514,6 +514,14 @@ module Rodauth
         @_rodauth ||= self.class.rodauth.new(self)
       end
     end
+
+    # :nocov:
+    if RUBY_VERSION >= '4.0'
+      def instance_variables_to_inspect
+        instance_variables.reject{|v| instance_variable_get(v).nil?}
+      end
+    end
+    # :nocov:
   end
 
   module ClassMethods


### PR DESCRIPTION
Now that all possible instance variables are initialized to `nil`, this inflates the `#inspect` output quite a bit, making it more difficult to focus on important details.

I think we can exclude those instance variables from the inspect output for brevity.